### PR TITLE
adding FuncDecl AST node type, with others

### DIFF
--- a/src/ast/AstNode.ts
+++ b/src/ast/AstNode.ts
@@ -1,4 +1,8 @@
+import { TypeTable } from "./symbols/TypeTable";
+
 export abstract class AstNode {
+
+    protected typeTable: TypeTable = TypeTable.getInstance();
 
     // Declaring return type as any for now, we can get more specific later as we go
     public abstract parse(): any;

--- a/src/ast/Comment.ts
+++ b/src/ast/Comment.ts
@@ -1,0 +1,21 @@
+import {AstNode} from "./AstNode";
+
+/**
+ * Represents the comments that a class, interface, or method may have
+ *
+ * e.g. ind "comments" STRLIST ded
+ */
+export default class Comment extends AstNode {
+
+    comments: string[];
+
+    public parse(): any {
+        // TODO: implement the rest.
+        this.comments = [];
+    }
+
+    public evaluate(): any {
+        // TODO: implement this.
+    }
+
+}

--- a/src/ast/CommentDecl.ts
+++ b/src/ast/CommentDecl.ts
@@ -5,7 +5,7 @@ import {AstNode} from "./AstNode";
  *
  * e.g. ind "comments" STRLIST ded
  */
-export default class Comment extends AstNode {
+export default class CommentDecl extends AstNode {
 
     comments: string[];
 

--- a/src/ast/ConstructorDecl.ts
+++ b/src/ast/ConstructorDecl.ts
@@ -1,0 +1,23 @@
+import {AstNode} from "./AstNode";
+import {VarList} from "./VarList";
+
+/**
+ * This represents a constructor as a node in our AST
+ *
+ * e.g. "constructor" modifier
+ *          "params" ParamDecl
+ */
+export default class ConstructorDecl extends AstNode {
+
+    modifier: string;
+    params: VarList;
+
+    public parse(): any {
+        this.params = new VarList();
+        // TODO: implement the rest.
+    }
+
+    public evaluate(): any {
+        // TODO: implement this.
+    }
+}

--- a/src/ast/FuncDecl.ts
+++ b/src/ast/FuncDecl.ts
@@ -1,0 +1,36 @@
+import {AstNode} from "./AstNode";
+import {VarList} from "./VarList";
+import CommentDecl from "./CommentDecl";
+
+/**
+ * Represents a function declaration in our language
+ *
+ * e.g. function modifier (async | static)? str
+ *          params []
+ *          comments?
+ *          (generate getter)?
+ *          (generate setter)?
+ *          (return TYPE)?
+ */
+export default class FuncDecl extends AstNode {
+
+    modifier: string;
+    isAsync: boolean;
+    isStatic: boolean;
+    name: string;
+    params: VarList;
+    comment: CommentDecl;
+    generateGetter: boolean;
+    generateSetter: boolean;
+    returnType: string;
+
+    public parse(): any {
+        this.params = new VarList();
+        this.comment = new CommentDecl();
+        // TODO: implement the rest.
+    }
+
+    public evaluate(): any {
+        // TODO: implement this.
+    }
+}

--- a/src/ast/ParamDecl.ts
+++ b/src/ast/ParamDecl.ts
@@ -1,0 +1,16 @@
+import {AstNode} from "./AstNode";
+import {VarList} from "./VarList";
+
+export default class ParamDecl extends AstNode {
+
+    params: VarList;
+
+    public parse(): any {
+        // TODO: implement the rest.
+        this.params = new VarList();
+    }
+
+    public evaluate(): any {
+        // TODO: implement this.
+    }
+}

--- a/src/ast/ParamDecl.ts
+++ b/src/ast/ParamDecl.ts
@@ -1,6 +1,13 @@
 import {AstNode} from "./AstNode";
 import {VarList} from "./VarList";
 
+/**
+ * Represents a parameter declaration AST node
+ *
+ * Take a look at the VarList class to see how this works, basically looks like
+ *
+ * [<type> name, <type> name, etc...]
+ */
 export default class ParamDecl extends AstNode {
 
     params: VarList;

--- a/src/ast/symbols/TypeTable.ts
+++ b/src/ast/symbols/TypeTable.ts
@@ -46,7 +46,7 @@ export class TypeTable {
     }
 
     public static getInstance(): TypeTable {
-        if (this.instance === null) {
+        if (this.instance === null || this.instance === undefined) {
             this.instance = new TypeTable();
         }
         return this.instance;


### PR DESCRIPTION
**What was done**
* added AST type for `FuncDecl`
* `AstNode` now owns an instance of `TypeTable` so we can use to typecheck while parsing.
* added AST type for `CommentDecl`
* added AST type for `ParamDecl`