### PR TITLE
Tokenizer implementation

### DIFF
--- a/src/ast/AstNode.ts
+++ b/src/ast/AstNode.ts
@@ -10,14 +10,4 @@ export abstract class AstNode {
 
     // Declaring return type as any for now, we can get more specific later as we go
     public abstract evaluate(): any;
-
-    /**
-     * Converts indentation token string to numerical value
-     *
-     * @param indentString  indentation token string with format _INDENT_LEVEL=[0-9]+_
-     * @returns number      extracted from indentation token
-     */
-    public extractTabLevel(indentString: string): number {
-        return parseInt(indentString.replace(/\D/g, ''));
-    }
 }

--- a/src/ast/AstNode.ts
+++ b/src/ast/AstNode.ts
@@ -11,4 +11,14 @@ export abstract class AstNode {
 
     // Declaring return type as any for now, we can get more specific later as we go
     public abstract evaluate(): any;
+
+    /**
+     * Converts indentation token string to numerical value
+     *
+     * @param indentString  indentation token string with format _INDENT_LEVEL=[0-9]+_
+     * @returns number      extracted from indentation token
+     */
+    public extractTabLevel(indentString: string): number {
+        return parseInt(indentString.replace(/\D/g, ''));
+    }
 }

--- a/src/ast/AstNode.ts
+++ b/src/ast/AstNode.ts
@@ -4,10 +4,9 @@ import {Tokenizer} from "../util/Tokenizer";
 export abstract class AstNode {
 
     protected typeTable: TypeTable = TypeTable.getInstance();
-    protected tokenizer: Tokenizer = Tokenizer.getInstance();
 
     // Declaring return type as any for now, we can get more specific later as we go
-    public abstract parse(): any;
+    public abstract parse(context: Tokenizer): any;
 
     // Declaring return type as any for now, we can get more specific later as we go
     public abstract evaluate(): any;

--- a/src/ast/ClassDecl.ts
+++ b/src/ast/ClassDecl.ts
@@ -4,6 +4,7 @@ import {ExtendsDecl} from "./ExtendsDecl";
 import {ImplementsDecl} from "./ImplementsDecl";
 import CommentDecl from "./CommentDecl";
 import FuncDecl from "./FuncDecl";
+import {Tokenizer} from "../util/Tokenizer";
 
 /**
  * Represents a Class a TypeScript project may have.
@@ -20,33 +21,33 @@ export class ClassDecl extends Content {
     functions: FuncDecl[];
 
 
-    public parse(): any {
-        this.isAbstract = this.tokenizer.checkToken("abstract");
-        this.tokenizer.getAndCheckNext("class");
-        this.className = this.tokenizer.getNext();
+    public parse(context: Tokenizer): any {
+        this.isAbstract = context.checkToken("abstract");
+        context.getAndCheckNext("class");
+        this.className = context.getNext();
 
-        if(this.tokenizer.checkToken("implements")) {
+        if(context.checkToken("implements")) {
             this.implementsNodes = new ImplementsDecl();
             this.implementsNodes.parse();
         }
 
-        if(this.tokenizer.checkToken("extends")) {
+        if(context.checkToken("extends")) {
             this.extendsNodes = new ExtendsDecl();
-            this.extendsNodes.parse();
+            this.extendsNodes.parse(context);
         }
 
         // TODO: implement the rest of this
         this.comments = new CommentDecl();
-        this.comments.parse();
+        this.comments.parse(context);
 
         this.fields = [];
         this.fields.forEach((field) => {
-            field.parse();
+            field.parse(context);
         });
 
         this.functions = [];
         this.functions.forEach((fn) => {
-            fn.parse();
+            fn.parse(context);
         });
     }
 

--- a/src/ast/CommentDecl.ts
+++ b/src/ast/CommentDecl.ts
@@ -1,4 +1,5 @@
 import {AstNode} from "./AstNode";
+import {Tokenizer} from "../util/Tokenizer";
 
 /**
  * Represents the comments that a class, interface, or method may have
@@ -9,7 +10,7 @@ export default class CommentDecl extends AstNode {
 
     comments: string[];
 
-    public parse(): any {
+    public parse(context: Tokenizer): any {
         // TODO: implement the rest.
         this.comments = [];
     }

--- a/src/ast/ConstructorDecl.ts
+++ b/src/ast/ConstructorDecl.ts
@@ -1,5 +1,6 @@
 import {AstNode} from "./AstNode";
 import {VarList} from "./VarList";
+import {Tokenizer} from "../util/Tokenizer";
 
 /**
  * This represents a constructor as a node in our AST
@@ -12,7 +13,7 @@ export default class ConstructorDecl extends AstNode {
     modifier: string;
     params: VarList;
 
-    public parse(): any {
+    public parse(context: Tokenizer): any {
         this.params = new VarList();
         // TODO: implement the rest.
     }

--- a/src/ast/DirDecl.ts
+++ b/src/ast/DirDecl.ts
@@ -4,6 +4,7 @@
  * e.g. dir str (DIR | CLASS| INTERFACE)+
  */
 import {Content} from "./Content";
+import {Tokenizer} from "../util/Tokenizer";
 
 export class DirDecl extends Content {
 
@@ -12,7 +13,7 @@ export class DirDecl extends Content {
     // The contents of this directory
     contents: Content[];
 
-    public parse(): any {
+    public parse(context: Tokenizer): any {
         // TODO: implement this.
     }
 

--- a/src/ast/ExtendsDecl.ts
+++ b/src/ast/ExtendsDecl.ts
@@ -4,14 +4,15 @@
  * e.g. 'extends' <type>
  */
 import {AstNode} from "./AstNode";
+import {Tokenizer} from "../util/Tokenizer";
 
 export class ExtendsDecl extends AstNode {
     parentName: string;
 
 
-    public parse(): any {
-        this.tokenizer.getAndCheckNext("extends");
-        this.parentName = this.tokenizer.getNext();
+    public parse(context: Tokenizer): any {
+        context.getAndCheckNext("extends");
+        this.parentName = context.getNext();
     }
 
     public evaluate(): any {

--- a/src/ast/FieldDecl.ts
+++ b/src/ast/FieldDecl.ts
@@ -1,5 +1,6 @@
 import {VarList} from "./VarList";
 import {AstNode} from "./AstNode";
+import {Tokenizer} from "../util/Tokenizer";
 
 /**
  * Represents a field declaration in the TypeScript DSL.
@@ -14,7 +15,7 @@ export class FieldDecl extends AstNode {
     generateGetter: boolean;
     generateSetter: boolean;
 
-    public parse(): any {
+    public parse(context: Tokenizer): any {
         // TODO: implement the rest.
         this.fields = new VarList();
     }

--- a/src/ast/FuncDecl.ts
+++ b/src/ast/FuncDecl.ts
@@ -1,6 +1,7 @@
 import {AstNode} from "./AstNode";
 import {VarList} from "./VarList";
 import CommentDecl from "./CommentDecl";
+import {Tokenizer} from "../util/Tokenizer";
 
 /**
  * Represents a function declaration in our language
@@ -24,7 +25,7 @@ export default class FuncDecl extends AstNode {
     generateSetter: boolean;
     returnType: string;
 
-    public parse(): any {
+    public parse(context: Tokenizer): any {
         this.params = new VarList();
         this.comment = new CommentDecl();
         // TODO: implement the rest.

--- a/src/ast/ImplementsDecl.ts
+++ b/src/ast/ImplementsDecl.ts
@@ -4,15 +4,16 @@
  * e.g. 'implements' <type> (',' <type>)*
  */
 import {AstNode} from "./AstNode";
+import {Tokenizer} from "../util/Tokenizer";
 
 export class ImplementsDecl extends AstNode {
     parentNames: string[];
 
 
-    public parse(): any {
-        this.tokenizer.getAndCheckNext("implements");
+    public parse(context: Tokenizer): any {
+        context.getAndCheckNext("implements");
         this.parentNames = [];
-        this.parentNames.push(this.tokenizer.getNext());
+        this.parentNames.push(context.getNext());
 
         // TODO: implement the rest of this
     }

--- a/src/ast/InterfaceDecl.ts
+++ b/src/ast/InterfaceDecl.ts
@@ -3,6 +3,7 @@ import {ExtendsDecl} from "./ExtendsDecl";
 import {FieldDecl} from "./FieldDecl";
 import CommentDecl from "./CommentDecl";
 import FuncDecl from "./FuncDecl";
+import {Tokenizer} from "../util/Tokenizer";
 
 /**
  * Represents an Interface a TypeScript project may have.
@@ -18,26 +19,26 @@ export class InterfaceDecl extends Content {
 
 
 
-    public parse(): any {
-        this.tokenizer.getAndCheckNext("interface");
-        this.interfaceName = this.tokenizer.getNext();
+    public parse(context: Tokenizer): any {
+        context.getAndCheckNext("interface");
+        this.interfaceName = context.getNext();
 
-        if(this.tokenizer.checkToken("extends")) {
+        if(context.checkToken("extends")) {
             this.extendsNodes = new ExtendsDecl();
         }
 
         // TODO: implement the rest of this.
         this.comments = new CommentDecl();
-        this.comments.parse();
+        this.comments.parse(context);
 
         this.fields = [];
         this.fields.forEach((field) => {
-            field.parse();
+            field.parse(context);
         });
 
         this.functions = [];
         this.functions.forEach((fn) => {
-            fn.parse();
+            fn.parse(context);
         });
     }
 

--- a/src/ast/ModuleDecl.ts
+++ b/src/ast/ModuleDecl.ts
@@ -4,12 +4,13 @@
  * e.g. modules ["@types/chai: 4.0.8", "chai: 4.1.2", "mocha: 4.1.0"]
  */
 import {AstNode} from "./AstNode";
+import {Tokenizer} from "../util/Tokenizer";
 
 export class ModuleDecl extends AstNode {
 
     modules: string[];
 
-    public parse(): any {
+    public parse(context: Tokenizer): any {
         // TODO: implement the rest.
         this.modules = [];
     }

--- a/src/ast/ParamDecl.ts
+++ b/src/ast/ParamDecl.ts
@@ -1,5 +1,6 @@
 import {AstNode} from "./AstNode";
 import {VarList} from "./VarList";
+import {Tokenizer} from "../util/Tokenizer";
 
 /**
  * Represents a parameter declaration AST node
@@ -12,7 +13,7 @@ export default class ParamDecl extends AstNode {
 
     params: VarList;
 
-    public parse(): any {
+    public parse(context: Tokenizer): any {
         // TODO: implement the rest.
         this.params = new VarList();
     }

--- a/src/ast/VarList.ts
+++ b/src/ast/VarList.ts
@@ -1,4 +1,5 @@
 import { AstNode } from "./AstNode";
+import {Tokenizer} from "../util/Tokenizer";
 
 /**
  * Represents a list of fields and their corresponding type. Used in declaring fields.
@@ -17,7 +18,7 @@ export class VarList extends AstNode {
         return Array.from(this.nameToType.keys());
     }
 
-    public parse(): any {
+    public parse(context: Tokenizer): any {
         // TODO: implement the rest.
         this.nameToType = new Map();
     }

--- a/src/util/FileSystem.ts
+++ b/src/util/FileSystem.ts
@@ -1,5 +1,12 @@
 import * as fs from "fs-extra";
 
+export class FileReadError extends Error {
+    constructor(...args: any[]) {
+        super(...args);
+        Error.captureStackTrace(this, FileReadError);
+    }
+}
+
 export class FileWriteError extends Error {
     constructor(...args: any[]) {
         super(...args);
@@ -57,5 +64,22 @@ export default class FileSystem {
 
     private createFullPath(fileName: string, path: string): string {
         return `${path}/${fileName}.ts`;
+    }
+
+    /**
+     * Reads in file contents at path/fileName synchronously, throws a FileReadError
+     *
+     * @param fileName  of the file to be read, must include extension
+     * @param path      path to the directory in which the file exists
+     */
+    public readFileSync(fileName: string, path: string): Buffer {
+        const fullPath: string = `${path}/${fileName}`;
+        try {
+            return fs.readFileSync(fullPath);
+        } catch (err) {
+            const msg: string = `FileSystem::reading file: ${fullPath} failed with error: ${err}`;
+            console.warn(msg);
+            throw new FileReadError(msg);
+        }
     }
 }

--- a/src/util/Tokenizer.ts
+++ b/src/util/Tokenizer.ts
@@ -9,7 +9,6 @@ export class TokenizerError extends Error {
 
 
 export class Tokenizer {
-    private tokenizerFile: string;
     private program: string;
     private tokens: string[][];
     private currentToken: {arr: number, pos: number};
@@ -50,7 +49,6 @@ export class Tokenizer {
 
     constructor(fileName: string, path: string) {
         // initialize fields
-        this.tokenizerFile =  `${path}/${fileName}`;
         this.tokens = [];
         this.currentToken = {arr: 0, pos: 1};
         // read contents of program

--- a/src/util/Tokenizer.ts
+++ b/src/util/Tokenizer.ts
@@ -1,3 +1,5 @@
+import FileSystem from "./FileSystem";
+
 export class TokenizerError extends Error {
     constructor(...args: any[]) {
         super(...args);
@@ -5,25 +7,50 @@ export class TokenizerError extends Error {
     }
 }
 
+// TODO: add all of the valid literals here.
+export enum TokenLiterals {
+    Class = "class",
+    Interface = "interface",
+    Implements = "implements",
+    Extends = "extends"
+}
+
 export class Tokenizer {
     private static tokenizerInstance: Tokenizer;
     private static tokenizerFile: string;
-    private tokens: string[];
+    private static program: string;
+    private tokens: string[][];
+    private currentToken: {arr: number, pos: number};
 
-    private constructor(fileName: string) {
-        Tokenizer.tokenizerFile =  fileName;
-        // TODO: implement this
+    private constructor(fileName: string, path: string) {
+        Tokenizer.tokenizerFile =  `${path}/${fileName}`;
+        // read contents of program
+        let fileSystem = new FileSystem();
+        Tokenizer.program = fileSystem.readFileSync(fileName, path).toString("utf8");
+        // tokenize program
+        this.tokenize();
     }
 
-    public static makeInstance(fileName: string) {
+    /**
+     * Creates an instance of Tokenizer and tokenizes contents of fileName
+     *
+     * @param fileName      of the file to be read and tokenized
+     * @returns Tokenizer   a Tokenizer with the tokenized contents of fileName
+     */
+    public static makeInstance(fileName: string, path: string) {
         if(!this.tokenizerInstance) {
-            this.tokenizerInstance = new Tokenizer(fileName);
+            this.tokenizerInstance = new Tokenizer(fileName, path);
         } else {
             const msg = `Called makeInstance with ${fileName},but already initialized with ${this.tokenizerFile}`;
             console.warn(msg);
         }
     }
 
+    /**
+     * Gets the instance of Tokenizer, throws a TokenizerError if no Tokenizer instance exists
+     *
+     * @returns Tokenizer   the instantiated Tokenizer
+     */
     public static getInstance(): Tokenizer {
         if(!this.tokenizerInstance) {
             const msg = `Must initialize Tokenizer with Tokenizer::makeInstance before calling Tokenizer::getInstance`;
@@ -31,6 +58,13 @@ export class Tokenizer {
             throw new TokenizerError(msg);
         }
         return this.tokenizerInstance;
+    }
+
+    /**
+     * Destroys the Tokenizer instance
+     */
+    public static destroyInstance() {
+        this.tokenizerInstance = undefined;
     }
 
     private tokenize() {

--- a/src/util/Tokenizer.ts
+++ b/src/util/Tokenizer.ts
@@ -7,23 +7,18 @@ export class TokenizerError extends Error {
     }
 }
 
-// TODO: add all of the valid literals here.
-export enum TokenLiterals {
-    Class = "class",
-    Interface = "interface",
-    Implements = "implements",
-    Extends = "extends"
-}
-
 export class Tokenizer {
     private static tokenizerInstance: Tokenizer;
     private static tokenizerFile: string;
     private static program: string;
-    private tokens: string[][];
+    private static tokens: string[][];
     private currentToken: {arr: number, pos: number};
 
     private constructor(fileName: string, path: string) {
+        // initialize fields
         Tokenizer.tokenizerFile =  `${path}/${fileName}`;
+        Tokenizer.tokens = [];
+        this.currentToken = {arr: 0, pos: 0};
         // read contents of program
         let fileSystem = new FileSystem();
         Tokenizer.program = fileSystem.readFileSync(fileName, path).toString("utf8");
@@ -68,7 +63,64 @@ export class Tokenizer {
     }
 
     private tokenize() {
-        // TODO: implement this
+        // TODO: add ALL valid tokens here.
+        let literals = [",", "\"", "\'", " ", "implements"];
+        // split program into subarrays for every nl
+        let programLines: string[] = Tokenizer.program.split("\n");
+
+        const reservedTokenWord = "_RESERVED_";
+
+        programLines.forEach((line) => {
+            // add token for indentation level of line, and remove whitespace at end of line.
+            line = "_INDENT_LEVEL=" + this.countTabs(line) + "_ " + line.trim();
+
+            // keeps track of whether we are inside quotation marks
+            let isSingleQuote = false;
+            let isDoubleQuote = false;
+
+            let splitLine = Array.from(line);
+            splitLine.forEach((str, index) => {
+                if(str === "\'") {
+                    splitLine[index] = "REPLACE QUOTE"
+
+                }
+                if(str === "\"") {
+                    splitLine[index] = "REPLACE DOUBLE QUOTE"
+                }
+            });
+
+            // create array from the string.
+            // if we are in a quote, do not add a quote (one of the quotes = true
+            // once we hit another quote of same kind, exit the skipping of any tokenizing.
+            // if both are false, then we can continue to tokenize the things we want to tokenize.
+            // split on the token.
+
+
+            // Tokenizer.literals.forEach((lit) => {
+            //     let litReg = new RegExp(lit, 'g');
+            //     line = line.replace(litReg, reservedTokenWord + lit + reservedTokenWord);
+            // });
+
+            // TODO: have to better handle this for case where we have strings for comments
+            // line = line.replace(/[ ]+/g, " ");
+            // Tokenizer.tokens.push(line.split(" "));
+            Tokenizer.tokens.push(splitLine);
+        });
+        console.log(Tokenizer.tokens);
+    }
+
+    /**
+     * Counts the number of space characters at the beginning of string
+     *
+     * @param programLine   string representing a single line in the file program
+     * @returns number      of space characters at the beginning of programLine
+     */
+    private countTabs(programLine: string): number {
+        let index = 0;
+        while(programLine.charAt(index) === " ") {
+            index++;
+        }
+        return index;
     }
 
     public getNext(): string {

--- a/src/util/Tokenizer.ts
+++ b/src/util/Tokenizer.ts
@@ -52,7 +52,7 @@ export class Tokenizer {
         // initialize fields
         this.tokenizerFile =  `${path}/${fileName}`;
         this.tokens = [];
-        this.currentToken = {arr: 0, pos: 0};
+        this.currentToken = {arr: 0, pos: 1};
         // read contents of program
         let fileSystem = new FileSystem();
         // 1. read whole program to single string
@@ -154,7 +154,7 @@ export class Tokenizer {
             next = this.tokens[this.currentToken.arr][this.currentToken.pos];
 
             if(this.tokens[this.currentToken.arr].length -1 == this.currentToken.pos) { //end of line
-                this.currentToken.pos = 0;
+                this.currentToken.pos = 1;
                 this.currentToken.arr++;
                 this.goToNextNonBlankLine();
                 if(this.tokens.length < this.currentToken.arr) {
@@ -211,5 +211,15 @@ export class Tokenizer {
             throw new TokenizerError(next + " did not match regex value " + regexp);
         }
         return next;
+    }
+    /**
+     * Gets the indentation level of the current line, if out of bounds, returns 0
+     * @returns number  indentation level of current line
+     */
+    public getCurrentLineTabLevel(): number {
+        if(this.currentToken.arr < this.tokens.length) {
+            return parseInt(this.tokens[this.currentToken.arr][0].replace(/\D/g, ''));
+        }
+        return 0;
     }
 }

--- a/test/ast/ClassDecl.spec.ts
+++ b/test/ast/ClassDecl.spec.ts
@@ -1,17 +1,7 @@
 import { expect } from "chai";
 import {ClassDecl} from "../../src/ast/ClassDecl";
-import {Tokenizer} from "../../src/util/Tokenizer";
 
 describe("ClassDecl extractTabLevel test", () => {
-
-    before(() => {
-        Tokenizer.makeInstance("test", "");
-
-    });
-
-    after(() => {
-        Tokenizer.destroyInstance();
-    });
 
     it("should successfully convert indent token string to numerical value", () => {
         let classNode = new ClassDecl();

--- a/test/ast/ClassDecl.spec.ts
+++ b/test/ast/ClassDecl.spec.ts
@@ -1,0 +1,20 @@
+import { expect } from "chai";
+import {ClassDecl} from "../../src/ast/ClassDecl";
+import {Tokenizer} from "../../src/util/Tokenizer";
+
+describe("ClassDecl extractTabLevel test", () => {
+
+    before(() => {
+        Tokenizer.makeInstance("test", "");
+
+    });
+
+    after(() => {
+        Tokenizer.destroyInstance();
+    });
+
+    it("should successfully convert indent token string to numerical value", () => {
+        let classNode = new ClassDecl();
+        expect(classNode.extractTabLevel('_INDENT_LEVEL=8_')).to.equal(8);
+    });
+});

--- a/test/ast/ClassDecl.spec.ts
+++ b/test/ast/ClassDecl.spec.ts
@@ -2,9 +2,4 @@ import { expect } from "chai";
 import {ClassDecl} from "../../src/ast/ClassDecl";
 
 describe("ClassDecl extractTabLevel test", () => {
-
-    it("should successfully convert indent token string to numerical value", () => {
-        let classNode = new ClassDecl();
-        expect(classNode.extractTabLevel('_INDENT_LEVEL=8_')).to.equal(8);
-    });
 });

--- a/test/testFiles/projectstructureex.txt
+++ b/test/testFiles/projectstructureex.txt
@@ -1,0 +1,4 @@
+dir src
+	class Time
+	dir TransitModels
+dir tests

--- a/test/testFiles/projectstructureex.txt
+++ b/test/testFiles/projectstructureex.txt
@@ -5,3 +5,12 @@ dir tests
 
 dir util
 
+
+
+
+	dir
+
+
+
+
+

--- a/test/testFiles/projectstructureex.txt
+++ b/test/testFiles/projectstructureex.txt
@@ -2,3 +2,6 @@ dir src
 	class Time
 	dir TransitModels
 dir tests
+
+dir util
+

--- a/test/testFiles/testTokenize.txt
+++ b/test/testFiles/testTokenize.txt
@@ -1,3 +1,0 @@
-dir 'test single quote       quote'
-dir "test double quote"
-dir "encapsulated 'quote'" dir

--- a/test/testFiles/testTokenize.txt
+++ b/test/testFiles/testTokenize.txt
@@ -1,0 +1,5 @@
+Testing if this gets read.
+        testing tab! implements
+
+more tests double line
+testing "doubel quote"

--- a/test/testFiles/testTokenize.txt
+++ b/test/testFiles/testTokenize.txt
@@ -1,5 +1,3 @@
-Testing if this gets read.
-        testing tab! implements
-
-more tests double line
-testing "doubel quote"
+dir 'test single quote       quote'
+dir "test double quote"
+dir "encapsulated 'quote'" dir

--- a/test/testFiles/transitFnExample.txt
+++ b/test/testFiles/transitFnExample.txt
@@ -1,0 +1,13 @@
+class Line implements TransitLine
+    fields private [string name, string lineNumber, Stop stop]
+    function public constructor
+        params [string name, string lineNumber, Stop stop]
+        comments [
+            "Constructor method for TransitLine",
+            "@param name - name of transit line",
+            "@param lineNumber - number of transit line",
+            "@param stop - stop",
+            "@returns TransitLine"
+        ]
+
+        returns TransitLine

--- a/test/util/FileSystem.spec.ts
+++ b/test/util/FileSystem.spec.ts
@@ -1,5 +1,5 @@
 import * as nodeFs from "fs-extra";
-import FileSystem, {FileDeleteError} from "../../src/util/FileSystem";
+import FileSystem, {FileDeleteError, FileReadError} from "../../src/util/FileSystem";
 import { expect } from "chai";
 
 describe("FileSystem write/delete tests", () => {
@@ -69,5 +69,27 @@ describe("FileSystem write/delete tests", () => {
         } finally {
             expect(result).to.equal("./codegen/test/src/Alice.ts");
         }
+    });
+});
+
+describe("FileSystem read tests", () => {
+
+    const testDir: string = "./test/testFiles";
+    let fs: FileSystem;
+
+    it("should successfully read contents of a file", () => {
+        fs = new FileSystem();
+        let contents = fs.readFileSync("projectstructureex.txt", testDir).toString();
+        expect(contents).to.equal("dir src\n" +
+            "\tclass Time\n" +
+            "\tdir TransitModels\n" +
+            "dir tests\n");
+    });
+
+    it("should throw a FileReadError when reading contents of a file that does not exist", () => {
+        fs = new FileSystem();
+        expect(() => {
+            fs.readFileSync("fakename.txt", testDir)
+        }).to.throw(FileReadError);
     });
 });

--- a/test/util/Tokenizer.spec.ts
+++ b/test/util/Tokenizer.spec.ts
@@ -23,6 +23,7 @@ describe("Tokenizer tokenize", () => {
         // blank line, goto dir util
         tokenizer.getNext();
         expect(tokenizer.getNext()).to.equal("dir");
+        expect(tokenizer.checkToken("util")).to.equal(true);
         expect(tokenizer.getNext()).to.equal("util");
         // blank line
         expect(tokenizer.getNext()).to.equal(Tokenizer.NO_MORE_TOKENS);

--- a/test/util/Tokenizer.spec.ts
+++ b/test/util/Tokenizer.spec.ts
@@ -1,29 +1,54 @@
 import { expect } from "chai";
 import {Tokenizer, TokenizerError} from "../../src/util/Tokenizer";
 
-describe("Tokenizer makeInstance/getInstance/destroyInstance", () => {
-
-    after(() => {
-        Tokenizer.destroyInstance();
-    });
-
-    it("creates, gets and deletes Tokenizer instance successfully", () => {
-        Tokenizer.makeInstance("projectstructureex.txt", "./test/testFiles");
-        expect(() => {Tokenizer.getInstance()}).to.not.throw();
-    });
-
-    it("throws a TokenizerError when getting a Tokenizer instance before creation ", () => {
-        expect(() => {Tokenizer.getInstance()}).to.throw(TokenizerError);
-    });
-});
-
 describe("Tokenizer tokenize", () => {
-    after(() => {
-        Tokenizer.destroyInstance();
+    it("gets and checks tokens in projectstructureex", () => {
+        let tokenizer: Tokenizer = new Tokenizer("projectstructureex.txt", "./test/testFiles");
+        //dir src
+        tokenizer.getNext();
+        expect(tokenizer.getNext()).to.equal("dir");
+        expect(tokenizer.getNext()).to.equal("src");
+        // 	class Time
+        tokenizer.getNext();
+        expect(tokenizer.getAndCheckNext("class")).to.equal("class");
+        expect(tokenizer.getNext()).to.equal("Time");
+        //	dir TransitModels
+        expect(tokenizer.getNext()).to.equal("_INDENT_LEVEL=8_");
+        expect(tokenizer.getAndCheckNext(Tokenizer.literals.Dir.val)).to.equal("dir");
+        expect(tokenizer.getNext()).to.equal("TransitModels");
+        // dir tests
+        tokenizer.getNext();
+        expect(tokenizer.getNext()).to.equal("dir");
+        expect(tokenizer.getNext()).to.equal("tests");
+        // blank line, goto dir util
+        tokenizer.getNext();
+        expect(tokenizer.getNext()).to.equal("dir");
+        expect(tokenizer.getNext()).to.equal("util");
+        // blank line
+        expect(tokenizer.getNext()).to.equal(Tokenizer.NO_MORE_TOKENS);
+        expect(tokenizer.checkToken(Tokenizer.NO_MORE_TOKENS)).to.equal(true);
     });
 
-    it("tokenizes successfully", () => {
-        Tokenizer.makeInstance("testTokenize.txt", "./test/testFiles");
+    it("gets and checks tokens from transitFnExample", () => {
+        let tokenizer: Tokenizer = new Tokenizer("transitFnExample.txt", "./test/testFiles");
+        // class Line implements TransitLine
+        tokenizer.getNext();
+        expect(tokenizer.getNext()).to.equal("class");
+        expect(tokenizer.getNext()).to.equal("Line");
+        expect(tokenizer.getNext()).to.equal("implements");
+        expect(tokenizer.getNext()).to.equal("TransitLine");
+        // 	fields private [string name, string lineNumber, Stop stop]
+        tokenizer.getNext();
+        expect(tokenizer.getAndCheckNext("fields")).to.equal("fields");
+        expect(tokenizer.getNext()).to.equal("private");
+        expect(tokenizer.getNext()).to.equal("[");
+        expect(tokenizer.getNext()).to.equal("string");
+        expect(tokenizer.getNext()).to.equal("name");
+        expect(tokenizer.getNext()).to.equal(",");
+        expect(tokenizer.getNext()).to.equal("string");
+        expect(tokenizer.getNext()).to.equal("lineNumber");
+        expect(tokenizer.getNext()).to.equal(",");
+        expect(tokenizer.getNext()).to.equal("Stop");
+        expect(tokenizer.getNext()).to.equal("stop");
     });
-
 });

--- a/test/util/Tokenizer.spec.ts
+++ b/test/util/Tokenizer.spec.ts
@@ -16,3 +16,14 @@ describe("Tokenizer makeInstance/getInstance/destroyInstance", () => {
         expect(() => {Tokenizer.getInstance()}).to.throw(TokenizerError);
     });
 });
+
+describe("Tokenizer tokenize", () => {
+    after(() => {
+        Tokenizer.destroyInstance();
+    });
+
+    it("tokenizes successfully", () => {
+        Tokenizer.makeInstance("testTokenize.txt", "./test/testFiles");
+    });
+
+});

--- a/test/util/Tokenizer.spec.ts
+++ b/test/util/Tokenizer.spec.ts
@@ -5,41 +5,42 @@ describe("Tokenizer tokenize", () => {
     it("gets and checks tokens in projectstructureex", () => {
         let tokenizer: Tokenizer = new Tokenizer("projectstructureex.txt", "./test/testFiles");
         //dir src
-        tokenizer.getNext();
+        expect(tokenizer.getCurrentLineTabLevel()).to.equal(0);
         expect(tokenizer.getNext()).to.equal("dir");
         expect(tokenizer.getNext()).to.equal("src");
         // 	class Time
-        tokenizer.getNext();
+        expect(tokenizer.getCurrentLineTabLevel()).to.equal(8);
         expect(tokenizer.getAndCheckNext("class")).to.equal("class");
         expect(tokenizer.getNext()).to.equal("Time");
         //	dir TransitModels
-        expect(tokenizer.getNext()).to.equal("_INDENT_LEVEL=8_");
+        expect(tokenizer.getCurrentLineTabLevel()).to.equal(8);
         expect(tokenizer.getAndCheckNext(Tokenizer.literals.Dir.val)).to.equal("dir");
         expect(tokenizer.getNext()).to.equal("TransitModels");
         // dir tests
-        tokenizer.getNext();
+        expect(tokenizer.getCurrentLineTabLevel()).to.equal(0);
         expect(tokenizer.getNext()).to.equal("dir");
         expect(tokenizer.getNext()).to.equal("tests");
         // blank line, goto dir util
-        tokenizer.getNext();
+        expect(tokenizer.getCurrentLineTabLevel()).to.equal(0);
         expect(tokenizer.getNext()).to.equal("dir");
         expect(tokenizer.checkToken("util")).to.equal(true);
         expect(tokenizer.getNext()).to.equal("util");
         // blank line
-        expect(tokenizer.getNext()).to.equal(Tokenizer.NO_MORE_TOKENS);
+        expect(tokenizer.getCurrentLineTabLevel()).to.equal(8);
+        expect(tokenizer.getNext()).to.equal("dir");
+        // end of file
         expect(tokenizer.checkToken(Tokenizer.NO_MORE_TOKENS)).to.equal(true);
+        expect(tokenizer.getCurrentLineTabLevel()).to.equal(0);
     });
 
     it("gets and checks tokens from transitFnExample", () => {
         let tokenizer: Tokenizer = new Tokenizer("transitFnExample.txt", "./test/testFiles");
         // class Line implements TransitLine
-        tokenizer.getNext();
         expect(tokenizer.getNext()).to.equal("class");
         expect(tokenizer.getNext()).to.equal("Line");
         expect(tokenizer.getNext()).to.equal("implements");
         expect(tokenizer.getNext()).to.equal("TransitLine");
         // 	fields private [string name, string lineNumber, Stop stop]
-        tokenizer.getNext();
         expect(tokenizer.getAndCheckNext("fields")).to.equal("fields");
         expect(tokenizer.getNext()).to.equal("private");
         expect(tokenizer.getNext()).to.equal("[");

--- a/test/util/Tokenizer.spec.ts
+++ b/test/util/Tokenizer.spec.ts
@@ -1,0 +1,18 @@
+import { expect } from "chai";
+import {Tokenizer, TokenizerError} from "../../src/util/Tokenizer";
+
+describe("Tokenizer makeInstance/getInstance/destroyInstance", () => {
+
+    after(() => {
+        Tokenizer.destroyInstance();
+    });
+
+    it("creates, gets and deletes Tokenizer instance successfully", () => {
+        Tokenizer.makeInstance("projectstructureex.txt", "./test/testFiles");
+        expect(() => {Tokenizer.getInstance()}).to.not.throw();
+    });
+
+    it("throws a TokenizerError when getting a Tokenizer instance before creation ", () => {
+        expect(() => {Tokenizer.getInstance()}).to.throw(TokenizerError);
+    });
+});


### PR DESCRIPTION
**Implementation for Tokenizer.**
- Updated Tokenizer so we can initialize multiple if we want to (easier for testing, consistent with Arthur's TS example)
- exposes constructor, getNext, checkToken, getAndCheckNext
- each new line starts with token of format: _INDENT_LEVEL=[0-9]+_
- tokenize: tokenizes program into string[][]. Does not tokenize anything inside quotation marks.

**Other updates:**
- Updated ASTNodes to pass Tokenizer context
- Added readFile for FileSystem wrapper

**TODO:**
- Need to also have a better way to handle '[' and ']' chars for tokenize (in the case user wants to specify an array type.
- Feel free to add more examples/ tests for Tokenize- there's a lot of different cases that need to be covered.