### PR TITLE
Class, Interface, extends, implements parse()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ test/**/*.spec.js.map
 test/*.map
 .DS_Store
 .env
+
+.idea/*
+package-lock.json

--- a/src/ast/ClassDecl.ts
+++ b/src/ast/ClassDecl.ts
@@ -12,18 +12,22 @@ import {Tokenizer} from "../util/Tokenizer";
  * e.g. ABS? ‘class’ str IMP? EXT? (nl COMMENT)? (nl FIELD)* (nl FUNC)* nl
  */
 export class ClassDecl extends Content {
-    isAbstract: boolean;
+    isAbstract: boolean = false;
     className: string;
     implementsNodes: ImplementsDecl;
     extendsNodes: ExtendsDecl;
     comments: CommentDecl;
-    fields: FieldDecl[];
-    functions: FuncDecl[];
+    fields: FieldDecl[] = [];
+    functions: FuncDecl[] = [];
 
 
     public parse(context: Tokenizer): any {
         let indentLevel: number = context.getCurrentLineTabLevel();
-        this.isAbstract = context.checkToken("abstract");
+        if(context.checkToken("abstract")) {
+            context.getNext();
+            this.isAbstract = true;
+        }
+
         context.getAndCheckNext("class");
         this.className = context.getNext();
 
@@ -38,7 +42,7 @@ export class ClassDecl extends Content {
         }
 
         if(context.getCurrentLineTabLevel() <= indentLevel) {
-            return;
+            return this;
         }
 
         if(context.checkToken("comments")) {
@@ -46,24 +50,17 @@ export class ClassDecl extends Content {
             this.comments.parse(context);
         }
 
-        if(context.getCurrentLineTabLevel() > indentLevel) {
-            return;
-        }
-
-        this.fields = [];
         while(context.getCurrentLineTabLevel() > indentLevel && context.checkToken("fields")) {
             let field: FieldDecl = new FieldDecl();
             field.parse(context);
             this.fields.push(field);
         }
 
-        this.functions = [];
-        while(context.getCurrentLineTabLevel() > indentLevel && context.checkToken("functions")) {
+        while(context.getCurrentLineTabLevel() > indentLevel && context.checkToken("function")) {
             let func: FuncDecl = new FuncDecl();
             func.parse(context);
             this.functions.push(func);
         }
-
         return this;
     }
 

--- a/src/ast/ClassDecl.ts
+++ b/src/ast/ClassDecl.ts
@@ -41,11 +41,7 @@ export class ClassDecl extends Content {
             this.extendsNodes.parse(context);
         }
 
-        if(context.getCurrentLineTabLevel() <= indentLevel) {
-            return this;
-        }
-
-        if(context.checkToken("comments")) {
+        if(context.getCurrentLineTabLevel() > indentLevel && context.checkToken("comments")) {
             this.comments = new CommentDecl();
             this.comments.parse(context);
         }
@@ -61,6 +57,7 @@ export class ClassDecl extends Content {
             func.parse(context);
             this.functions.push(func);
         }
+        this.typeTable.addClass(this.className);
         return this;
     }
 

--- a/src/ast/ClassDecl.ts
+++ b/src/ast/ClassDecl.ts
@@ -63,6 +63,8 @@ export class ClassDecl extends Content {
             func.parse(context);
             this.functions.push(func);
         }
+
+        return this;
     }
 
     public evaluate(): any {

--- a/src/ast/ExtendsDecl.ts
+++ b/src/ast/ExtendsDecl.ts
@@ -13,6 +13,7 @@ export class ExtendsDecl extends AstNode {
     public parse(context: Tokenizer): any {
         context.getAndCheckNext("extends");
         this.parentName = context.getNext();
+        return this;
     }
 
     public evaluate(): any {

--- a/src/ast/ImplementsDecl.ts
+++ b/src/ast/ImplementsDecl.ts
@@ -15,7 +15,11 @@ export class ImplementsDecl extends AstNode {
         this.parentNames = [];
         this.parentNames.push(context.getNext());
 
-        // TODO: implement the rest of this
+        while(context.checkToken("\,")) {
+            context.getNext();
+            this.parentNames.push(context.getNext());
+        }
+        return this;
     }
 
     public evaluate(): any {

--- a/test/ast/ClassDecl.spec.ts
+++ b/test/ast/ClassDecl.spec.ts
@@ -1,5 +1,8 @@
 import { expect } from "chai";
 import {ClassDecl} from "../../src/ast/ClassDecl";
 
-describe("ClassDecl extractTabLevel test", () => {
+describe("ClassDecl parse test", () => {
+    it("parses class definition", () => {
+
+    });
 });

--- a/test/ast/ClassDecl.spec.ts
+++ b/test/ast/ClassDecl.spec.ts
@@ -3,6 +3,7 @@ import {ClassDecl} from "../../src/ast/ClassDecl";
 import {Tokenizer} from "../../src/util/Tokenizer";
 import {ImplementsDecl} from "../../src/ast/ImplementsDecl";
 import {ExtendsDecl} from "../../src/ast/ExtendsDecl";
+import {TypeTable} from "../../src/ast/symbols/TypeTable";
 
 describe("ClassDecl parse test", () => {
     it("parses single-line, simple class definition", () => {
@@ -14,8 +15,11 @@ describe("ClassDecl parse test", () => {
         expect(classDec.implementsNodes).to.be.undefined;
         expect(classDec.extendsNodes.parentName).to.equal("TimeClass");
         expect(classDec.comments).to.be.undefined;
-        expect(classDec.fields).to.be.undefined;
-        expect(classDec.functions).to.be.undefined;
+        expect(classDec.fields.length).to.equal(0);
+        expect(classDec.functions.length).to.equal(0);
+        let typeTable : TypeTable = TypeTable.getInstance();
+        expect(typeTable.table.size).to.equal(4);
+        expect(typeTable.getTypeNode(classDec.className)).to.not.be.undefined;
     });
 
     it("parses complex class definition", () => {

--- a/test/ast/ClassDecl.spec.ts
+++ b/test/ast/ClassDecl.spec.ts
@@ -1,8 +1,63 @@
 import { expect } from "chai";
 import {ClassDecl} from "../../src/ast/ClassDecl";
+import {Tokenizer} from "../../src/util/Tokenizer";
+import {ImplementsDecl} from "../../src/ast/ImplementsDecl";
+import {ExtendsDecl} from "../../src/ast/ExtendsDecl";
 
 describe("ClassDecl parse test", () => {
-    it("parses class definition", () => {
+    it("parses single-line, simple class definition", () => {
+        let tokenizer : Tokenizer = new Tokenizer("classDeclSimple.txt", "./test/testFiles");
+        let classDec : ClassDecl = new ClassDecl();
+        classDec = classDec.parse(tokenizer);
+        expect(classDec.isAbstract).to.be.true;
+        expect(classDec.className).to.equal("Time");
+        expect(classDec.implementsNodes).to.be.undefined;
+        expect(classDec.extendsNodes.parentName).to.equal("TimeClass");
+        expect(classDec.comments).to.be.undefined;
+        expect(classDec.fields).to.be.undefined;
+        expect(classDec.functions).to.be.undefined;
+    });
+
+    it("parses complex class definition", () => {
+        let tokenizer : Tokenizer = new Tokenizer("classDeclComplex.txt", "./test/testFiles");
+        let classDec : ClassDecl = new ClassDecl();
+        classDec = classDec.parse(tokenizer);
+        expect(classDec.isAbstract).to.be.false;
+        expect(classDec.className).to.equal("Time");
+
+        expect(classDec.implementsNodes.parentNames.length).to.equal(2);
+        expect(classDec.implementsNodes.parentNames[0]).to.equal("ITime");
+        expect(classDec.implementsNodes.parentNames[1]).to.equal("DateTime");
+
+        expect(classDec.extendsNodes.parentName).to.equal("TimeClass");
+
+        expect(classDec.comments.comments.length).to.equal(1);
+        expect(classDec.comments.comments[0]).to.equal("This is the time class");
+
+        expect(classDec.fields.length).to.equal(2);
+        //fields private [number dayOfWeek, number hour, number minute]
+        expect(classDec.fields[0].modifier).to.equal("private");
+        expect(classDec.fields[0].fields.nameToType.size).to.equal(3);
+        expect(classDec.fields[0].generateGetter).to.equal(true);
+        expect(classDec.fields[0].generateSetter).to.equal(true);
+
+        expect(classDec.fields[1].modifier).to.equal("public");
+        expect(classDec.fields[1].fields.nameToType.size).to.equal(1);
+        expect(classDec.fields[1].generateGetter).to.equal(true);
+        expect(classDec.fields[1].generateSetter).to.equal(false);
+
+        expect(classDec.functions.length).to.equal(1);
+        // function public getDate
+        // params [string id, string content, InsightDatasetKind kind]
+        // comments ["creates a new Time object from given date",
+        //     "{param} date - date object to parse time object from"]
+        // returns Date
+        expect(classDec.functions[0].modifier).to.equal("public");
+        expect(classDec.functions[0].maybeStatic.isStatic).to.be.false;
+        expect(classDec.functions[0].maybeAsync.isAsync).to.be.false;
+        expect(classDec.functions[0].params.nameToType.size).to.equal(3);
+        expect(classDec.functions[0].comment.comments.length).to.equal(2);
+        expect(classDec.functions[0].returnDecl.returnType).to.equal("Date");
 
     });
 });

--- a/test/ast/ExtendsDecl.spec.ts
+++ b/test/ast/ExtendsDecl.spec.ts
@@ -1,0 +1,13 @@
+import { expect } from "chai";
+import {ExtendsDecl} from "../../src/ast/ExtendsDecl";
+import {Tokenizer} from "../../src/util/Tokenizer";
+
+describe("ExtendsDecl parse test", () => {
+    it("parses extends type line", () => {
+        let tokenizer : Tokenizer = new Tokenizer("extends.txt", "./test/testFiles");
+        let extendsDec : ExtendsDecl = new ExtendsDecl();
+        expect(JSON.stringify(extendsDec.parse(tokenizer)))
+            .to.equal("{\"typeTable\":{\"table\":{}},\"parentName\":\"Animal\"}");
+    });
+
+});

--- a/test/ast/ExtendsDecl.spec.ts
+++ b/test/ast/ExtendsDecl.spec.ts
@@ -6,8 +6,7 @@ describe("ExtendsDecl parse test", () => {
     it("parses extends type line", () => {
         let tokenizer : Tokenizer = new Tokenizer("extends.txt", "./test/testFiles");
         let extendsDec : ExtendsDecl = new ExtendsDecl();
-        expect(JSON.stringify(extendsDec.parse(tokenizer)))
-            .to.equal("{\"typeTable\":{\"table\":{}},\"parentName\":\"Animal\"}");
+        expect(extendsDec.parse(tokenizer).parentName).to.equal("Animal");
     });
 
 });

--- a/test/ast/ImplementsDecl.spec.ts
+++ b/test/ast/ImplementsDecl.spec.ts
@@ -1,0 +1,22 @@
+import { expect } from "chai";
+import {Tokenizer} from "../../src/util/Tokenizer";
+import {ImplementsDecl} from "../../src/ast/ImplementsDecl";
+
+describe("ImplementsDecl parse test", () => {
+    it("parses single implements type line", () => {
+        let tokenizer : Tokenizer = new Tokenizer("implementssingle.txt", "./test/testFiles");
+        let implementsDec : ImplementsDecl = new ImplementsDecl();
+        let parents = implementsDec.parse(tokenizer).parentNames;
+        expect(parents.length).to.equal(1);
+        expect(parents[0]).to.equal("Animal");
+    });
+
+    it("parses multi-implements type line", () => {
+        let tokenizer : Tokenizer = new Tokenizer("implementsmultiple.txt", "./test/testFiles");
+        let implementsDec : ImplementsDecl = new ImplementsDecl();
+        let parents = implementsDec.parse(tokenizer).parentNames;
+        expect(parents.length).to.equal(2);
+        expect(parents[0]).to.equal("Transit");
+        expect(parents[1]).to.equal("IStop");
+    });
+});

--- a/test/ast/InterfaceDecl.spec.ts
+++ b/test/ast/InterfaceDecl.spec.ts
@@ -1,0 +1,41 @@
+import { expect } from "chai";
+import {Tokenizer} from "../../src/util/Tokenizer";
+import {InterfaceDecl} from "../../src/ast/InterfaceDecl";
+import {TypeTable} from "../../src/ast/symbols/TypeTable";
+
+describe("ClassDecl parse test", () => {
+    it("parses single-line, simple interface definition", () => {
+        let typeTable : TypeTable = TypeTable.getInstance();
+        expect(typeTable.table.size).to.equal(3);
+        let tokenizer : Tokenizer = new Tokenizer("interfaceDeclSimple.txt", "./test/testFiles");
+        let intDec : InterfaceDecl = new InterfaceDecl();
+        intDec = intDec.parse(tokenizer);
+        expect(intDec.interfaceName).to.equal("TransitLine");
+        expect(intDec.comments).to.be.undefined;
+        expect(intDec.extendsNodes.parentName).to.equal("Transit");
+        expect(intDec.fieldDecl).to.be.undefined;
+        expect(intDec.functions.length).to.equal(0);
+
+        expect(typeTable.table.size).to.equal(4);
+        expect(typeTable.getTypeNode(intDec.interfaceName)).to.not.be.undefined;
+
+    });
+
+    it("throws an error parsing invalid interface definition", () => {
+        // TODO: implement this test case may require changes to how we tokenize... (does not currently throw error)
+        let tokenizer : Tokenizer = new Tokenizer("interfaceSimpleInvalid.txt", "./test/testFiles");
+        let intDec : InterfaceDecl = new InterfaceDecl();
+        intDec.parse(tokenizer);
+    });
+
+    it("parses complex interface definition", () => {
+        let tokenizer : Tokenizer = new Tokenizer("interfaceDeclComplex.txt", "./test/testFiles");
+        let intDec : InterfaceDecl = new InterfaceDecl();
+        intDec = intDec.parse(tokenizer);
+        expect(intDec.interfaceName).to.equal("TransitLine");
+        expect(intDec.comments).to.be.undefined;
+        expect(intDec.fieldDecl).to.be.undefined;
+        expect(intDec.functions.length).to.equal(2);
+
+    });
+});

--- a/test/testFiles/classDeclComplex.txt
+++ b/test/testFiles/classDeclComplex.txt
@@ -1,0 +1,12 @@
+class Time implements ITime, DateTime extends TimeClass
+    comments ["This is the time class"]
+    fields private [number dayOfWeek, number hour, number minute]
+        generate getters
+        generate setters
+    fields public [number date]
+        generate getters
+    function public getDate
+        params [string id, string content, InsightDatasetKind kind]
+        comments ["creates a new Time object from given date",
+            "{param} date - date object to parse time object from"]
+        returns Date

--- a/test/testFiles/classDeclSimple.txt
+++ b/test/testFiles/classDeclSimple.txt
@@ -1,0 +1,1 @@
+abstract class Time extends TimeClass

--- a/test/testFiles/extends.txt
+++ b/test/testFiles/extends.txt
@@ -1,0 +1,1 @@
+extends Animal

--- a/test/testFiles/implementsmultiple.txt
+++ b/test/testFiles/implementsmultiple.txt
@@ -1,0 +1,1 @@
+implements Transit, IStop

--- a/test/testFiles/implementssingle.txt
+++ b/test/testFiles/implementssingle.txt
@@ -1,0 +1,1 @@
+implements Animal

--- a/test/testFiles/interfaceDeclComplex.txt
+++ b/test/testFiles/interfaceDeclComplex.txt
@@ -1,0 +1,9 @@
+interface TransitLine
+    function public getNumberOfStops
+        params []
+        comments ["Returns the number of stops in the transit line"]
+        returns number
+    function public getRoute
+        params []
+        comments ["Returns the street names of transit route"]
+        returns string

--- a/test/testFiles/interfaceDeclSimple.txt
+++ b/test/testFiles/interfaceDeclSimple.txt
@@ -1,0 +1,1 @@
+interface TransitLine extends Transit

--- a/test/testFiles/interfaceSimpleInvalid.txt
+++ b/test/testFiles/interfaceSimpleInvalid.txt
@@ -1,0 +1,1 @@
+interface TransitLine implements Line extends Transit


### PR DESCRIPTION
Implementation and tests for Class, Interface, extends, implements parse()

Added a couple of TODOs:

1. How do we want to handle Interfaces not being allowed to have non-public fields?
2. Current implementation of parse() parses valid input fine, but not great on the throwing errors immediately. Considering how we want to implement better handling of invalid data- may change Tokenizer. If this is the option that happens- I'll update the various parse implementations as needed. 

If you have any thoughts on those 2 points, feel free to start a discussion here- open to suggestions!