### PR TITLE
Fixing bug for FuncDecl edge cases

### DIFF
--- a/src/ast/FuncDecl.ts
+++ b/src/ast/FuncDecl.ts
@@ -22,12 +22,13 @@ export default class FuncDecl extends AstNode {
     name: string;
     params: VarList;
     comment: CommentDecl;
-    returnDecl: ReturnDecl;
+    returnDecl: ReturnDecl = new ReturnDecl();
 
 
     public parse(context: Tokenizer): any {
         let indentLevel: number = context.getCurrentLineTabLevel();
         context.getAndCheckNext("function");
+        this.returnDecl.returnType = "void";
         this.modifier = context.getNext();
 
         this.maybeStatic = new StaticDecl();
@@ -35,17 +36,20 @@ export default class FuncDecl extends AstNode {
         this.maybeAsync = new AsyncDecl();
         this.maybeAsync.parse(context);
 
+        this.params = new VarList();
+        this.comment = new CommentDecl();
+
         this.name = context.getNext();
+        if (context.checkToken("returns")) {
+            this.returnDecl.parse(context);
+        }
         if (context.getCurrentLineTabLevel() <= indentLevel) return;
 
-        context.getAndCheckNext("params");
-        this.params = new VarList();
-        this.params.parse(context);
-
-        this.comment = new CommentDecl();
-        this.comment.parse(context);
-
-        this.returnDecl = new ReturnDecl();
+        if (context.checkToken("params")) {
+            context.getAndCheckNext("params");
+            this.params.parse(context);
+            this.comment.parse(context);
+        }
         this.returnDecl.parse(context);
     }
 

--- a/test/ast/FuncDecl.spec.ts
+++ b/test/ast/FuncDecl.spec.ts
@@ -83,4 +83,30 @@ describe("FuncDecl parse tests", () => {
         expect(funcDecl.comment.comments).to.deep.equal(["Add Dataset function", "returns ids of datasets on disk"]);
         expect(funcDecl.returnDecl.returnType).to.equal(`Promise<string>`);
     });
+
+    it("should parse a function declaration with no params at all", () => {
+        // function public getTime returns number
+        const tokenizer: Tokenizer = new Tokenizer("funcDeclOptionalParams.txt", "./test/testFiles");
+        funcDecl.parse(tokenizer);
+        expect(funcDecl.modifier).to.equal("public");
+        expect(funcDecl.name).to.equal("getTime");
+        expect(funcDecl.params.nameToType.size).to.equal(0);
+        expect(funcDecl.maybeAsync.isAsync).to.equal(false);
+        expect(funcDecl.maybeStatic.isStatic).to.equal(false);
+        expect(funcDecl.comment.comments).to.deep.equal([]);
+        expect(funcDecl.returnDecl.returnType).to.equal("number");
+    });
+
+    it("should parse a function declaration with no params, no return type", () => {
+        // function private foo
+        const tokenizer: Tokenizer = new Tokenizer("funcDeclSimplest.txt", "./test/testFiles");
+        funcDecl.parse(tokenizer);
+        expect(funcDecl.modifier).to.equal("private");
+        expect(funcDecl.name).to.equal("foo");
+        expect(funcDecl.params.nameToType.size).to.equal(0);
+        expect(funcDecl.maybeAsync.isAsync).to.equal(false);
+        expect(funcDecl.maybeStatic.isStatic).to.equal(false);
+        expect(funcDecl.comment.comments).to.deep.equal([]);
+        expect(funcDecl.returnDecl.returnType).to.equal("void");
+    });
 });

--- a/test/testFiles/funcDeclOptionalParams.txt
+++ b/test/testFiles/funcDeclOptionalParams.txt
@@ -1,0 +1,1 @@
+function public getTime returns number

--- a/test/testFiles/funcDeclSimplest.txt
+++ b/test/testFiles/funcDeclSimplest.txt
@@ -1,0 +1,1 @@
+function private foo


### PR DESCRIPTION
**What's new?**

The `parse()` method for `FuncDecl` can now handle the following cases
```
function private foo

function private foo returns string
```

Thanks @kiyomih for letting me know!