### PR TITLE
Adding utility for printing AST nodes

### DIFF
--- a/src/ast/AstNode.ts
+++ b/src/ast/AstNode.ts
@@ -1,9 +1,14 @@
 import { TypeTable } from "./symbols/TypeTable";
 import {Tokenizer} from "../util/Tokenizer";
+import TypeScriptEngine from "../codegen/TypeScriptEngine";
+import PrintUtil from "../util/PrintUtil";
+import ts = require("typescript");
 
 export abstract class AstNode {
 
     protected typeTable: TypeTable = TypeTable.getInstance();
+    protected engine: TypeScriptEngine = new TypeScriptEngine();
+    protected printer: PrintUtil = new PrintUtil(ts.createPrinter({ newLine: ts.NewLineKind.LineFeed }));
 
     // Declaring return type as any for now, we can get more specific later as we go
     public abstract parse(context: Tokenizer): any;

--- a/src/codegen/TypeScriptEngine.ts
+++ b/src/codegen/TypeScriptEngine.ts
@@ -2,7 +2,6 @@ import * as ts from "typescript";
 import {FunctionDeclaration,
         Modifier,
         ParameterDeclaration,
-        Printer,
         SyntaxKind,
         TypeNode,
         ClassDeclaration,
@@ -18,11 +17,9 @@ import CommentDecl from "../ast/CommentDecl";
 
 export default class TypeScriptEngine {
 
-    private readonly printer: Printer;
     private readonly typeTable: TypeTable;
 
     constructor() {
-        this.printer = ts.createPrinter({ newLine: ts.NewLineKind.LineFeed });
         this.typeTable = TypeTable.getInstance();
     }
 

--- a/src/util/PrintUtil.ts
+++ b/src/util/PrintUtil.ts
@@ -1,0 +1,31 @@
+import { Printer, SourceFile } from "typescript";
+import ts = require("typescript");
+
+export default class PrintUtil {
+
+    private readonly printer: Printer;
+    private readonly file: SourceFile;
+
+    constructor(printer: Printer) {
+        this.printer = printer;
+        this.file = ts.createSourceFile(
+            "TypeScript.ts",
+            "",
+            ts.ScriptTarget.Latest,
+            /*setParentNodes*/ false,
+            ts.ScriptKind.TS
+        );
+    }
+
+    /**
+     * Given an TypeScript API AST node, return the string representation of it.
+     * @param tsNode the node which we want to print.
+     */
+    public tsNodeToString(tsNode: ts.Node): string {
+        return this.printer.printNode(
+            ts.EmitHint.Unspecified,
+            tsNode,
+            this.file
+        );
+    }
+}

--- a/test/TypeScriptEngine.spec.ts
+++ b/test/TypeScriptEngine.spec.ts
@@ -55,11 +55,11 @@ describe("TypeScriptEngine tests", () => {
         vars.nameToType = new Map();
         const expected: ParameterDeclaration[] = [
             ts.createParameter(
-            /* decorators */ undefined,
-            /* modifiers */ undefined,
-            /* dotDotToken */ undefined,
-            "bar",
-            /* questionToken */ undefined,
+                /* decorators */ undefined,
+                /* modifiers */ undefined,
+                /* dotDotToken */ undefined,
+                "bar",
+                /* questionToken */ undefined,
                 ts.createKeywordTypeNode(ts.SyntaxKind.BooleanKeyword)),
             ts.createParameter(
                 /* decorators */ undefined,
@@ -122,11 +122,11 @@ describe("TypeScriptEngine tests", () => {
             /* typeParameters */ undefined,
             [
                 ts.createParameter(
-                /* decorators */ undefined,
-                /* modifiers */ undefined,
-                /* dotDotToken */ undefined,
-                "name",
-                /* questionToken */ undefined,
+                    /* decorators */ undefined,
+                    /* modifiers */ undefined,
+                    /* dotDotToken */ undefined,
+                    "name",
+                    /* questionToken */ undefined,
                     ts.createKeywordTypeNode(ts.SyntaxKind.StringKeyword)),
                 ts.createParameter(
                     /* decorators */ undefined,
@@ -334,7 +334,7 @@ describe("TypeScriptEngine tests", () => {
                 ts.createTypeReferenceNode("ParameterDecl", undefined),
                 baseFunDecl.name,
                 /* questionToken */ undefined
-            ),ts.createPropertySignature(
+            ), ts.createPropertySignature(
                 /* modifiers */ undefined,
                 "foo",
                 /* questionToken */ undefined,
@@ -400,7 +400,7 @@ describe("TypeScriptEngine tests", () => {
                     )],
                 ts.createTypeReferenceNode("ParameterDecl", undefined),
                 /* body */ undefined
-            ),ts.createProperty(
+            ), ts.createProperty(
                 undefined,
                 /* modifiers */ undefined,
                 "foo",
@@ -467,43 +467,44 @@ describe("TypeScriptEngine tests", () => {
             )]
         ));
 
-    it('should add a multiline comment with only one line to interface declaration', () => {
-        // interface FooBar { }
-        const name: string = "FooBar";
-        baseInterfaceDecl.interfaceName = name;
-        baseInterfaceDecl.functions = [];
-        baseInterfaceDecl.fieldDecl = new FieldDecl();
-        baseInterfaceDecl.fieldDecl.fields = new VarList();
-        baseInterfaceDecl.comments = new CommentDecl();
-        baseInterfaceDecl.comments.comments = ['comment line 1'];
-        const result: InterfaceDeclaration = engine.createInterface(baseInterfaceDecl);
-        const resultStr: string = nodeToString(result);
-        expect(resultStr).to.equal(`/**\n * comment line 1\n */\ninterface FooBar {\n}`);
-    });
+        it('should add a multiline comment with only one line to interface declaration', () => {
+            // interface FooBar { }
+            const name: string = "FooBar";
+            baseInterfaceDecl.interfaceName = name;
+            baseInterfaceDecl.functions = [];
+            baseInterfaceDecl.fieldDecl = new FieldDecl();
+            baseInterfaceDecl.fieldDecl.fields = new VarList();
+            baseInterfaceDecl.comments = new CommentDecl();
+            baseInterfaceDecl.comments.comments = ['comment line 1'];
+            const result: InterfaceDeclaration = engine.createInterface(baseInterfaceDecl);
+            const resultStr: string = nodeToString(result);
+            expect(resultStr).to.equal(`/**\n * comment line 1\n */\ninterface FooBar {\n}`);
+        });
 
-    it('should add a multiline comment with multiple lines to interface declaration', () => {
-        const name: string = "FooBar";
-        baseInterfaceDecl.interfaceName = name;
-        baseInterfaceDecl.functions = [];
-        baseInterfaceDecl.fieldDecl = new FieldDecl();
-        baseInterfaceDecl.fieldDecl.fields = new VarList();
-        baseInterfaceDecl.comments = new CommentDecl();
-        baseInterfaceDecl.comments.comments = ['comment line 1', 'comment line 2', 'comment line 3'];
-        const result: InterfaceDeclaration = engine.createInterface(baseInterfaceDecl);
-        const resultStr: string = nodeToString(result);
-        expect(resultStr).to.equal(`/**\n * comment line 1\n * comment line 2\n * comment line 3\n */\ninterface FooBar {\n}`);
-    });
+        it('should add a multiline comment with multiple lines to interface declaration', () => {
+            const name: string = "FooBar";
+            baseInterfaceDecl.interfaceName = name;
+            baseInterfaceDecl.functions = [];
+            baseInterfaceDecl.fieldDecl = new FieldDecl();
+            baseInterfaceDecl.fieldDecl.fields = new VarList();
+            baseInterfaceDecl.comments = new CommentDecl();
+            baseInterfaceDecl.comments.comments = ['comment line 1', 'comment line 2', 'comment line 3'];
+            const result: InterfaceDeclaration = engine.createInterface(baseInterfaceDecl);
+            const resultStr: string = nodeToString(result);
+            expect(resultStr).to.equal(`/**\n * comment line 1\n * comment line 2\n * comment line 3\n */\ninterface FooBar {\n}`);
+        });
 
-    it('should not add a comment to interface declaration', () => {
-        const name: string = "FooBar";
-        baseInterfaceDecl.interfaceName = name;
-        baseInterfaceDecl.functions = [];
-        baseInterfaceDecl.fieldDecl = new FieldDecl();
-        baseInterfaceDecl.fieldDecl.fields = new VarList();
-        baseInterfaceDecl.comments = new CommentDecl();
-        baseInterfaceDecl.comments.comments = [];
-        const result: InterfaceDeclaration = engine.createInterface(baseInterfaceDecl);
-        const resultStr: string = nodeToString(result);
-        expect(resultStr).to.equal(`interface FooBar {\n}`);
+        it('should not add a comment to interface declaration', () => {
+            const name: string = "FooBar";
+            baseInterfaceDecl.interfaceName = name;
+            baseInterfaceDecl.functions = [];
+            baseInterfaceDecl.fieldDecl = new FieldDecl();
+            baseInterfaceDecl.fieldDecl.fields = new VarList();
+            baseInterfaceDecl.comments = new CommentDecl();
+            baseInterfaceDecl.comments.comments = [];
+            const result: InterfaceDeclaration = engine.createInterface(baseInterfaceDecl);
+            const resultStr: string = nodeToString(result);
+            expect(resultStr).to.equal(`interface FooBar {\n}`);
+        });
     });
 });

--- a/test/ast/ClassDecl.spec.ts
+++ b/test/ast/ClassDecl.spec.ts
@@ -60,7 +60,7 @@ describe("ClassDecl parse test", () => {
         expect(classDec.functions[0].maybeStatic.isStatic).to.be.false;
         expect(classDec.functions[0].maybeAsync.isAsync).to.be.false;
         expect(classDec.functions[0].params.nameToType.size).to.equal(3);
-        expect(classDec.functions[0].comment.comments.length).to.equal(2);
+        expect(classDec.functions[0].comments.comments.length).to.equal(2);
         expect(classDec.functions[0].returnDecl.returnType).to.equal("Date");
 
     });


### PR DESCRIPTION
**What's done?**
* factored out the Printer functionality from `TypeScriptEngine` to not violate single responsibility (TSE should not also be responsible for printing AST nodes)