### PR TITLE
Implement ImportStringBuilder

### DIFF
--- a/src/ast/AstNode.ts
+++ b/src/ast/AstNode.ts
@@ -4,10 +4,12 @@ import FileSystem from "../util/FileSystem";
 import TypeScriptEngine from "../codegen/TypeScriptEngine";
 import PrintUtil from "../util/PrintUtil";
 import ts = require("typescript");
+import {PathTable} from "../util/PathTable";
 
 export abstract class AstNode {
 
     protected typeTable: TypeTable = TypeTable.getInstance();
+    protected pathTable: PathTable = PathTable.getInstance();
     protected fileSystem: FileSystem  = new FileSystem();
     protected engine: TypeScriptEngine = new TypeScriptEngine();
     protected printer: PrintUtil = new PrintUtil(ts.createPrinter({ newLine: ts.NewLineKind.LineFeed }));

--- a/src/ast/ClassDecl.ts
+++ b/src/ast/ClassDecl.ts
@@ -20,7 +20,6 @@ export class ClassDecl extends Content {
     fields: FieldDecl[] = [];
     functions: FuncDecl[] = [];
 
-
     public parse(context: Tokenizer): any {
         let indentLevel: number = context.getCurrentLineTabLevel();
         if(context.checkToken("abstract")) {
@@ -57,7 +56,10 @@ export class ClassDecl extends Content {
             func.parse(context);
             this.functions.push(func);
         }
+
         this.typeTable.addClass(this.className);
+        this.pathTable.addTypePath(this.className, this.getAbsolutePath());
+
         return this;
     }
 
@@ -69,5 +71,9 @@ export class ClassDecl extends Content {
         this.extendsNodes.typeCheck();
         this.fields.forEach((fieldDecl: FieldDecl) => fieldDecl.typeCheck());
         this.functions.forEach((funcDecl: FuncDecl) => funcDecl.typeCheck());
+    }
+
+    public getAbsolutePath(): string {
+        return this.parentPath + "/" + this.className + ".ts";
     }
 }

--- a/src/ast/ClassDecl.ts
+++ b/src/ast/ClassDecl.ts
@@ -74,6 +74,6 @@ export class ClassDecl extends Content {
     }
 
     public getAbsolutePath(): string {
-        return this.parentPath + "/" + this.className + ".ts";
+        return `${this.parentPath}/${this.className}.ts`;
     }
 }

--- a/src/ast/Content.ts
+++ b/src/ast/Content.ts
@@ -16,4 +16,6 @@ export abstract class Content extends AstNode {
         super();
         this.parentPath = parentPath;
     }
+
+    public abstract getAbsolutePath(): string;
 }

--- a/src/ast/InterfaceDecl.ts
+++ b/src/ast/InterfaceDecl.ts
@@ -45,6 +45,8 @@ export class InterfaceDecl extends Content {
         }
 
         this.typeTable.addInterface(this.interfaceName);
+        this.pathTable.addTypePath(this.interfaceName, this.getAbsolutePath());
+
         return this;
     }
 
@@ -56,5 +58,9 @@ export class InterfaceDecl extends Content {
         this.extendsNodes.typeCheck();
         this.fieldDecl.typeCheck();
         this.functions.forEach((funcDecl: FuncDecl) => funcDecl.typeCheck());
+    }
+
+    public getAbsolutePath(): string {
+        return this.parentPath + "/" + this.interfaceName + ".ts";
     }
 }

--- a/src/ast/VarList.ts
+++ b/src/ast/VarList.ts
@@ -9,10 +9,10 @@ import {TypeCheckError} from "./symbols/TypeTable";
  */
 export class VarList extends AstNode {
 
-    nameToType: Map<string, string> = new Map();
+    nameTypeMap: Map<string, string> = new Map();
 
     public addPair(name: string, type: string): void {
-        this.nameToType.set(name, type);
+        this.nameTypeMap.set(name, type);
     }
 
     public parse(context: Tokenizer): any {

--- a/src/ast/VarList.ts
+++ b/src/ast/VarList.ts
@@ -37,7 +37,7 @@ export class VarList extends AstNode {
     }
 
     public typeCheck(): void {
-        const fieldTypes: string[] = Array.from(this.nameToType.values());
+        const fieldTypes: string[] = Array.from(this.nameTypeMap.values());
         const allValidTypes: boolean = this.typeTable.areValidTypes(fieldTypes);
         if (!allValidTypes) {
             throw new TypeCheckError(`At least one type from: ${fieldTypes} was not declared`);

--- a/src/codegen/TypeScriptEngine.ts
+++ b/src/codegen/TypeScriptEngine.ts
@@ -110,14 +110,14 @@ export default class TypeScriptEngine {
     }
 
     private fieldsToTypeElement(fields: VarList): TypeElement[] {
-        const fieldsAsList: [string, string][] = Array.from(fields.nameToType.entries());
+        const fieldsAsList: [string, string][] = Array.from(fields.nameTypeMap.entries());
         return fieldsAsList.map((nameTypePair) => {
             return this.makePropertySignature(nameTypePair[0], nameTypePair[1]);
         });
     }
 
     private fieldsToClassElement(fields: VarList): ClassElement[] {
-        const fieldsAsList: [string, string][] = Array.from(fields.nameToType.entries());
+        const fieldsAsList: [string, string][] = Array.from(fields.nameTypeMap.entries());
         return fieldsAsList.map((nameTypePair) => {
             return this.makeProperty(nameTypePair[0], nameTypePair[1]);
         });
@@ -145,7 +145,7 @@ export default class TypeScriptEngine {
     }
 
     private varsToParamDecl(vars: VarList): ParameterDeclaration[] {
-        const varsAsList: [string, string][] = Array.from(vars.nameToType.entries());
+        const varsAsList: [string, string][] = Array.from(vars.nameTypeMap.entries());
         return varsAsList.map((nameTypePair) => {
             return this.makeParamDecl(nameTypePair[0], nameTypePair[1]);
         });

--- a/src/util/ImportStringBuilder.ts
+++ b/src/util/ImportStringBuilder.ts
@@ -1,0 +1,230 @@
+import {ClassDecl} from "../ast/ClassDecl";
+import {PathTable} from "./PathTable";
+import {VarList} from "../ast/VarList";
+import {AstNode} from "../ast/AstNode";
+import {InterfaceDecl} from "../ast/InterfaceDecl";
+import FuncDecl from "../ast/FuncDecl";
+
+export class ImportStringBuilder {
+
+    /**
+     * Extracts the non primitive types used by a class/interface declaration then
+     * returns a series of import strings to be located at the top of a class/interface declaration.
+     *
+     * e.g. import {VarList} from "../ast/VarList";
+     *      import {PathTable} from "./PathTable";
+     *      import {ClassDecl} from "../ast/ClassDecl";
+     *
+     * @param node              the class/interface declaration doing the importing
+     */
+    public static getImportsString(node: AstNode): string {
+        if (node instanceof ClassDecl) {
+            return this.getClassImportsString(node);
+        } else if (node instanceof InterfaceDecl) {
+            return this.getInterfaceImportsString(node);
+        } else {
+            const msg: string = `Given node: ${node} cannot have imports string`;
+            console.warn(msg);
+            throw new Error(msg);
+        }
+    }
+
+    /**
+     * Extracts the non primitive types used by a class declaration then
+     * returns a series of import strings to be located at the top of a class declaration.
+     *
+     * e.g. import {VarList} from "../ast/VarList";
+     *      import {PathTable} from "./PathTable";
+     *      import {ClassDecl} from "../ast/ClassDecl";
+     *
+     * @param classDec              the class declaration doing the importing
+     */
+    private static getClassImportsString(classDec: ClassDecl): string {
+        let classNonPrimitives = this.extractNonPrimitiveTypesFromClass(classDec);
+        let importStrBody: string = this.buildImportStringBody(classDec.getAbsolutePath(), classNonPrimitives);
+
+        return importStrBody;
+    }
+
+    /**
+     * Extracts the non primitive types used by a interface declaration then
+     * returns a series of import strings to be located at the top of a interface declaration.
+     *
+     * e.g. import {VarList} from "../ast/VarList";
+     *      import {PathTable} from "./PathTable";
+     *      import {ClassDecl} from "../ast/ClassDecl";
+     *
+     * @param interfaceDec              the interface declaration doing the importing
+     */
+    private static getInterfaceImportsString(interfaceDec: InterfaceDecl): string {
+        let interfaceNonPrimitives = this.extractNonPrimitiveTypesFromInterface(interfaceDec);
+        let importStrBody: string = this.buildImportStringBody(interfaceDec.getAbsolutePath(), interfaceNonPrimitives);
+
+        return importStrBody;
+    }
+
+    /**
+     * Return series import strings to be located at the top of a class/interface declaration.
+     *
+     * e.g. import {VarList} from "../ast/VarList";
+     *      import {PathTable} from "./PathTable";
+     *      import {ClassDecl} from "../ast/ClassDecl";
+     *
+     * @param importerPath          path to the class/interface
+     * @param nonPrimitives    the set of non primitive types used by the class/interface declaration
+     */
+    private static buildImportStringBody(importerPath: string, nonPrimitives: Set<string>): string {
+        let pathTable = PathTable.getInstance();
+        let importStrBody: string = "";
+
+        nonPrimitives.forEach((importItem: string) => {
+            let nonPrimitivePath = pathTable.getPath(importItem);
+            if (nonPrimitivePath !== undefined) {
+                let importStr = this.buildImportString(importItem, importerPath, nonPrimitivePath);
+
+                importStrBody += importStr;
+            }
+        });
+
+        return importStrBody;
+    }
+
+    /**
+     * Return what the import string would be for an imported type in the given class' path.
+     *
+     * e.g. import {VarList} from "../ast/VarList";
+     *
+     * How to get from src path to dst path?
+     * 1) Find common point between two paths
+     * 2) Compute number of "cd .." commands needed to get to common point from src
+     * 3) Concatenate "../" with path from common point to dst
+     *
+     *
+     * @param nonPrimitiveName      the name of the type to be imported
+     * @param classOrInterfacePath  the path to the class/interface doing the importing
+     * @param nonPrimitivePath      the path to the type to be imported
+     */
+    private static buildImportString(nonPrimitiveName: string, classOrInterfacePath: string, nonPrimitivePath: string): string {
+        let dstArr = nonPrimitivePath.split("/");
+        let srcArr = classOrInterfacePath.split("/");
+
+        let i = 0;
+        while (i < srcArr.length || i < dstArr.length) {
+            if (dstArr[i] !== srcArr[i]) {
+                break;
+            }
+
+            i++;
+        }
+
+        let pathToDstFromCommonPoint = dstArr.slice(i);
+
+        let importPath: string = "";
+
+        // If in same directory, simply do a ./<NonPrimitiveParam>
+        if (i === dstArr.length - 1 && i === srcArr.length - 1) {
+            importPath = "./" + pathToDstFromCommonPoint.join("/");
+        } else { // Need to go "up" a directory by j = (srcArr.length - 1) - i
+            for (let j = srcArr.length - 1 - i; j > 0; j--) {
+                importPath += "../";
+            }
+
+            importPath += pathToDstFromCommonPoint.join("/");
+        }
+
+        return `import {${nonPrimitiveName}} from \"${importPath}\";\n`;
+    }
+
+    /**
+     * Extracts the non primitive types from a Class' fields and functions
+     *
+     * @param classDec  the Class declaration to extract non primitives from
+     */
+    private static extractNonPrimitiveTypesFromClass(classDec: ClassDecl): Set<string> {
+        let classNonPrimitives = new Set<string>();
+
+        // Extract from fields
+        for (let fieldDec of classDec.fields) {
+            let nonPrimitives = this.extractNonPrimitiveTypesFromVarList(fieldDec.fields);
+
+            nonPrimitives.forEach((nonPrimitive: string) => {
+                classNonPrimitives.add(nonPrimitive);
+            });
+        }
+
+        // Extract from functions
+        for (let funcDec of classDec.functions) {
+            let nonPrimitivesParams = this.extractNonPrimitiveTypesFromFunctions(funcDec);
+
+            nonPrimitivesParams.forEach((nonPrimitive: string) => {
+                classNonPrimitives.add(nonPrimitive);
+            });
+        }
+
+        return classNonPrimitives;
+    }
+
+    /**
+     * Extracts the non primitive types from a Interfaces' fields and functions
+     *
+     * @param interfaceDec  the Interface declaration to extract non primitives from
+     */
+    private static extractNonPrimitiveTypesFromInterface(interfaceDec: InterfaceDecl): Set<string> {
+        let interfaceNonPrimitives = new Set<string>();
+
+        // Extract from fields
+        let nonPrimitives = this.extractNonPrimitiveTypesFromVarList(interfaceDec.fieldDecl.fields);
+
+        nonPrimitives.forEach((nonPrimitive: string) => {
+            interfaceNonPrimitives.add(nonPrimitive);
+        });
+
+
+        // Extract from functions
+        for (let funcDec of interfaceDec.functions) {
+            let nonPrimitivesParams = this.extractNonPrimitiveTypesFromFunctions(funcDec);
+
+            nonPrimitivesParams.forEach((nonPrimitive: string) => {
+                interfaceNonPrimitives.add(nonPrimitive);
+            });
+        }
+
+        return interfaceNonPrimitives;
+    }
+
+    /**
+     * Extracts the non primitive types from a function declaration (params and return type)
+     *
+     * @param FuncDec  the FuncDec to extract fields from
+     */
+    private static extractNonPrimitiveTypesFromFunctions(funcDec: FuncDecl): Set<string> {
+        let nonPrimitiveTypes = new Set<string>();
+
+        let nonPrimitivesParams = this.extractNonPrimitiveTypesFromVarList(funcDec.params);
+        nonPrimitivesParams.forEach((nonPrimitive: string) => {
+            nonPrimitiveTypes.add(nonPrimitive);
+        });
+
+        let nonPrimitiveReturnType = funcDec.returnDecl.returnType;
+        if (nonPrimitiveReturnType !== "void") {
+            nonPrimitiveTypes.add(nonPrimitiveReturnType);
+        }
+
+        return nonPrimitiveTypes;
+    }
+
+    /**
+     * Extracts the non primitive types from a VarList type map
+     *
+     * @param varList  the VarList to extract fields from
+     */
+    public static extractNonPrimitiveTypesFromVarList(varList: VarList): Set<string> {
+        let nonPrimitiveTypes = new Set<string>();
+
+        varList.nameTypeMap.forEach((value: string) => {
+            nonPrimitiveTypes.add(value);
+        });
+
+        return nonPrimitiveTypes;
+    }
+}

--- a/src/util/PathTable.ts
+++ b/src/util/PathTable.ts
@@ -23,7 +23,6 @@ export class PathTable {
     }
 
     public getPath(typeName: string): string {
-        const typePath: string = this.table.get(typeName);
-        return typePath;
+        return this.table.get(typeName);
     }
 }

--- a/src/util/PathTable.ts
+++ b/src/util/PathTable.ts
@@ -1,0 +1,29 @@
+/**
+ * Represents the paths to the types we have available in our language. It acts as a basic map from a type name
+ * to its path.
+ *
+ * Whenever we declare a new type, we should make a new entry for it in the map.
+ */
+export class PathTable {
+
+    private table: Map<string, string> = new Map();
+    static instance: PathTable = null;
+
+    private constructor() {}
+
+    public static getInstance(): PathTable {
+        if (this.instance === null || this.instance === undefined) {
+            this.instance = new PathTable();
+        }
+        return this.instance;
+    }
+
+    public addTypePath(typeName: string, path: string): void {
+        this.table.set(typeName, path);
+    }
+
+    public getPath(typeName: string): string {
+        const typePath: string = this.table.get(typeName);
+        return typePath;
+    }
+}

--- a/test/TypeScriptEngine.spec.ts
+++ b/test/TypeScriptEngine.spec.ts
@@ -507,4 +507,4 @@ describe("TypeScriptEngine tests", () => {
             expect(resultStr).to.equal(`interface FooBar {\n}`);
         });
     });
-})});
+});

--- a/test/TypeScriptEngine.spec.ts
+++ b/test/TypeScriptEngine.spec.ts
@@ -52,7 +52,7 @@ describe("TypeScriptEngine tests", () => {
 
     it("should convert a VarList to a ParamDeclaration[]", () => {
         const vars: VarList = new VarList();
-        vars.nameToType = new Map();
+        vars.nameTypeMap = new Map();
         const expected: ParameterDeclaration[] = [
             ts.createParameter(
                 /* decorators */ undefined,
@@ -85,7 +85,7 @@ describe("TypeScriptEngine tests", () => {
     });
 
     it("should create a simple function declaration - foo(): number", () => {
-        baseVarList.nameToType = new Map();
+        baseVarList.nameTypeMap = new Map();
         baseFunDecl.name = "foo";
         baseFunDecl.modifier = "public";
         baseFunDecl.params = baseVarList;
@@ -105,7 +105,7 @@ describe("TypeScriptEngine tests", () => {
 
     it("should create a parameterized function declaration", () => {
         // public makeParamDecl(name: string, type: string): ParameterDecl;
-        baseVarList.nameToType = new Map();
+        baseVarList.nameTypeMap = new Map();
         baseVarList.addPair("name", "string");
         baseVarList.addPair("type", "string");
         TypeTable.getInstance().addClass("ParameterDecl"); // add the class so we have access to it in the test
@@ -142,7 +142,7 @@ describe("TypeScriptEngine tests", () => {
     });
 
     it('should add a multiline comment with only one line to the function', () => {
-        baseVarList.nameToType = new Map();
+        baseVarList.nameTypeMap = new Map();
         baseFunDecl.name = "foo";
         baseFunDecl.modifier = "public";
         baseFunDecl.params = baseVarList;
@@ -155,7 +155,7 @@ describe("TypeScriptEngine tests", () => {
     });
 
     it('should add a multiline comment with multiple lines to the function', () => {
-        baseVarList.nameToType = new Map();
+        baseVarList.nameTypeMap = new Map();
         baseFunDecl.name = "foo";
         baseFunDecl.modifier = "public";
         baseFunDecl.params = baseVarList;
@@ -168,7 +168,7 @@ describe("TypeScriptEngine tests", () => {
     });
 
     it('should not add a comment to the function', () => {
-        baseVarList.nameToType = new Map();
+        baseVarList.nameTypeMap = new Map();
         baseFunDecl.name = "foo";
         baseFunDecl.modifier = "public";
         baseFunDecl.params = baseVarList;
@@ -245,7 +245,7 @@ describe("TypeScriptEngine tests", () => {
          * */
         const name: string = "IInsightFacade";
         const funName: string = "makeParamDecl";
-        baseVarList.nameToType = new Map();
+        baseVarList.nameTypeMap = new Map();
         baseVarList.addPair("name", "string");
         baseVarList.addPair("type", "string");
         TypeTable.getInstance().addClass("ParameterDecl"); // add the class so we have access to it in the test
@@ -295,7 +295,7 @@ describe("TypeScriptEngine tests", () => {
          * */
         const name: string = "IInsightFacade";
         const funName: string = "makeParamDecl";
-        baseVarList.nameToType = new Map();
+        baseVarList.nameTypeMap = new Map();
         baseVarList.addPair("name", "string");
         baseVarList.addPair("type", "string");
         TypeTable.getInstance().addClass("ParameterDecl"); // add the class so we have access to it in the test
@@ -352,7 +352,7 @@ describe("TypeScriptEngine tests", () => {
          * */
         const name: string = "InsightFacade";
         const funName: string = "makeParamDecl";
-        baseVarList.nameToType = new Map();
+        baseVarList.nameTypeMap = new Map();
         baseVarList.addPair("name", "string");
         baseVarList.addPair("type", "string");
         TypeTable.getInstance().addClass("ParameterDecl"); // add the class so we have access to it in the test
@@ -419,7 +419,7 @@ describe("TypeScriptEngine tests", () => {
          * */
         const name: string = "InsightFacade";
         const funName: string = "makeParamDecl";
-        baseVarList.nameToType = new Map();
+        baseVarList.nameTypeMap = new Map();
         baseVarList.addPair("name", "string");
         baseVarList.addPair("type", "string");
         TypeTable.getInstance().addClass("ParameterDecl"); // add the class so we have access to it in the test

--- a/test/ast/ClassDecl.spec.ts
+++ b/test/ast/ClassDecl.spec.ts
@@ -43,12 +43,12 @@ describe("ClassDecl parse test", () => {
         expect(classDec.fields.length).to.equal(2);
         //fields private [number dayOfWeek, number hour, number minute]
         expect(classDec.fields[0].modifier).to.equal("private");
-        expect(classDec.fields[0].fields.nameToType.size).to.equal(3);
+        expect(classDec.fields[0].fields.nameTypeMap.size).to.equal(3);
         expect(classDec.fields[0].generateGetter).to.equal(true);
         expect(classDec.fields[0].generateSetter).to.equal(true);
 
         expect(classDec.fields[1].modifier).to.equal("public");
-        expect(classDec.fields[1].fields.nameToType.size).to.equal(1);
+        expect(classDec.fields[1].fields.nameTypeMap.size).to.equal(1);
         expect(classDec.fields[1].generateGetter).to.equal(true);
         expect(classDec.fields[1].generateSetter).to.equal(false);
 
@@ -61,7 +61,7 @@ describe("ClassDecl parse test", () => {
         expect(classDec.functions[0].modifier).to.equal("public");
         expect(classDec.functions[0].maybeStatic.isStatic).to.be.false;
         expect(classDec.functions[0].maybeAsync.isAsync).to.be.false;
-        expect(classDec.functions[0].params.nameToType.size).to.equal(3);
+        expect(classDec.functions[0].params.nameTypeMap.size).to.equal(3);
         expect(classDec.functions[0].comments.comments.length).to.equal(2);
         expect(classDec.functions[0].returnDecl.returnType).to.equal("Date");
 

--- a/test/ast/ConstructorDecl.spec.ts
+++ b/test/ast/ConstructorDecl.spec.ts
@@ -14,15 +14,15 @@ describe("ConstructorDecl parse test", () => {
         const tokenizer: Tokenizer = new Tokenizer("constructorNoParams.txt", "./test/testFiles");
         constructor.parse(tokenizer);
         expect(constructor.modifier).to.equal("public");
-        expect(constructor.params.nameToType.size).to.equal(0);
+        expect(constructor.params.nameTypeMap.size).to.equal(0);
     });
 
     it ("should parse a constructor with params", () => {
         const tokenizer: Tokenizer = new Tokenizer("constructorWithParams.txt", "./test/testFiles");
         constructor.parse(tokenizer);
         expect(constructor.modifier).to.equal("private");
-        expect(constructor.params.nameToType.get("facade")).to.equal("IInsightFacade");
-        expect(constructor.params.nameToType.get("engine")).to.equal("QueryEngine");
+        expect(constructor.params.nameTypeMap.get("facade")).to.equal("IInsightFacade");
+        expect(constructor.params.nameTypeMap.get("engine")).to.equal("QueryEngine");
     });
 
 });

--- a/test/ast/FieldDecl.spec.ts
+++ b/test/ast/FieldDecl.spec.ts
@@ -15,15 +15,15 @@ describe("FieldDecl tokenizer test", () => {
         const tokenizer: Tokenizer = new Tokenizer("fieldDeclExample.txt", "./test/testFiles");
         fieldDecl.parse(tokenizer);
         expect(fieldDecl.modifier).to.equal("private");
-        expect(fieldDecl.fields.nameToType.get("foo")).to.deep.equal("string");
+        expect(fieldDecl.fields.nameTypeMap.get("foo")).to.deep.equal("string");
     });
 
     it("should parse a field declaration with getters", () => {
         const tokenizer: Tokenizer = new Tokenizer("fieldDeclWithGetter.txt", "./test/testFiles");
         fieldDecl.parse(tokenizer);
         expect(fieldDecl.modifier).to.equal("private");
-        expect(fieldDecl.fields.nameToType.get("foo")).to.deep.equal("string");
-        expect(fieldDecl.fields.nameToType.get("facade")).to.deep.equal("IInsightFacade");
+        expect(fieldDecl.fields.nameTypeMap.get("foo")).to.deep.equal("string");
+        expect(fieldDecl.fields.nameTypeMap.get("facade")).to.deep.equal("IInsightFacade");
         expect(fieldDecl.generateGetter).to.equal(true);
         expect(fieldDecl.generateSetter).to.equal(false);
     });
@@ -32,8 +32,8 @@ describe("FieldDecl tokenizer test", () => {
         const tokenizer: Tokenizer = new Tokenizer("fieldDeclWithGetterSetter.txt", "./test/testFiles");
         fieldDecl.parse(tokenizer);
         expect(fieldDecl.modifier).to.equal("private");
-        expect(fieldDecl.fields.nameToType.get("foo")).to.deep.equal("string");
-        expect(fieldDecl.fields.nameToType.get("facade")).to.deep.equal("IInsightFacade");
+        expect(fieldDecl.fields.nameTypeMap.get("foo")).to.deep.equal("string");
+        expect(fieldDecl.fields.nameTypeMap.get("facade")).to.deep.equal("IInsightFacade");
         expect(fieldDecl.generateGetter).to.equal(true);
         expect(fieldDecl.generateSetter).to.equal(true);
     });

--- a/test/ast/FuncDecl.spec.ts
+++ b/test/ast/FuncDecl.spec.ts
@@ -17,7 +17,7 @@ describe("FuncDecl parse tests", () => {
         funcDecl.parse(tokenizer);
         expect(funcDecl.modifier).to.equal("private");
         expect(funcDecl.name).to.equal("foo");
-        expect(funcDecl.params.nameToType.size).to.equal(0);
+        expect(funcDecl.params.nameTypeMap.size).to.equal(0);
         expect(funcDecl.maybeAsync.isAsync).to.equal(false);
         expect(funcDecl.maybeStatic.isStatic).to.equal(false);
         expect(funcDecl.comments.comments).to.deep.equal([]);
@@ -30,7 +30,7 @@ describe("FuncDecl parse tests", () => {
         funcDecl.parse(tokenizer);
         expect(funcDecl.modifier).to.equal("public");
         expect(funcDecl.name).to.equal("bar");
-        expect(funcDecl.params.nameToType.size).to.equal(2);
+        expect(funcDecl.params.nameTypeMap.size).to.equal(2);
         expect(funcDecl.maybeAsync.isAsync).to.equal(false);
         expect(funcDecl.maybeStatic.isStatic).to.equal(false);
         expect(funcDecl.comments.comments).to.deep.equal([]);
@@ -42,7 +42,7 @@ describe("FuncDecl parse tests", () => {
         funcDecl.parse(tokenizer);
         expect(funcDecl.modifier).to.equal("private");
         expect(funcDecl.name).to.equal("foo");
-        expect(funcDecl.params.nameToType.size).to.equal(0);
+        expect(funcDecl.params.nameTypeMap.size).to.equal(0);
         expect(funcDecl.maybeAsync.isAsync).to.equal(false);
         expect(funcDecl.maybeStatic.isStatic).to.equal(false);
         expect(funcDecl.comments.comments).to.deep.equal(["ayy lmao"]);
@@ -54,7 +54,7 @@ describe("FuncDecl parse tests", () => {
         funcDecl.parse(tokenizer);
         expect(funcDecl.modifier).to.equal("public");
         expect(funcDecl.name).to.equal("bar");
-        expect(funcDecl.params.nameToType.size).to.equal(2);
+        expect(funcDecl.params.nameTypeMap.size).to.equal(2);
         expect(funcDecl.maybeAsync.isAsync).to.equal(true);
         expect(funcDecl.maybeStatic.isStatic).to.equal(false);
         expect(funcDecl.comments.comments).to.deep.equal([]);
@@ -66,7 +66,7 @@ describe("FuncDecl parse tests", () => {
         funcDecl.parse(tokenizer);
         expect(funcDecl.modifier).to.equal("public");
         expect(funcDecl.name).to.equal("bar");
-        expect(funcDecl.params.nameToType.size).to.equal(2);
+        expect(funcDecl.params.nameTypeMap.size).to.equal(2);
         expect(funcDecl.maybeAsync.isAsync).to.equal(true);
         expect(funcDecl.maybeStatic.isStatic).to.equal(true);
         expect(funcDecl.comments.comments).to.deep.equal([]);
@@ -78,7 +78,7 @@ describe("FuncDecl parse tests", () => {
         funcDecl.parse(tokenizer);
         expect(funcDecl.modifier).to.equal("public");
         expect(funcDecl.name).to.equal("addDataset");
-        expect(funcDecl.params.nameToType.size).to.equal(3);
+        expect(funcDecl.params.nameTypeMap.size).to.equal(3);
         expect(funcDecl.maybeAsync.isAsync).to.equal(true);
         expect(funcDecl.maybeStatic.isStatic).to.equal(true);
         expect(funcDecl.comments.comments).to.deep.equal(["Add Dataset function", "returns ids of datasets on disk"]);
@@ -91,7 +91,7 @@ describe("FuncDecl parse tests", () => {
         funcDecl.parse(tokenizer);
         expect(funcDecl.modifier).to.equal("public");
         expect(funcDecl.name).to.equal("getTime");
-        expect(funcDecl.params.nameToType.size).to.equal(0);
+        expect(funcDecl.params.nameTypeMap.size).to.equal(0);
         expect(funcDecl.maybeAsync.isAsync).to.equal(false);
         expect(funcDecl.maybeStatic.isStatic).to.equal(false);
         expect(funcDecl.comments.comments).to.deep.equal([]);
@@ -104,7 +104,7 @@ describe("FuncDecl parse tests", () => {
         funcDecl.parse(tokenizer);
         expect(funcDecl.modifier).to.equal("private");
         expect(funcDecl.name).to.equal("foo");
-        expect(funcDecl.params.nameToType.size).to.equal(0);
+        expect(funcDecl.params.nameTypeMap.size).to.equal(0);
         expect(funcDecl.maybeAsync.isAsync).to.equal(false);
         expect(funcDecl.maybeStatic.isStatic).to.equal(false);
         expect(funcDecl.comments.comments).to.deep.equal([]);

--- a/test/util/ImportStringBuilder.spec.ts
+++ b/test/util/ImportStringBuilder.spec.ts
@@ -1,0 +1,221 @@
+import {expect} from "chai";
+import {ClassDecl} from "../../src/ast/ClassDecl";
+import {PathTable} from "../../src/util/PathTable";
+import {ImportStringBuilder} from "../../src/util/ImportStringBuilder";
+import {FieldDecl} from "../../src/ast/FieldDecl";
+import {VarList} from "../../src/ast/VarList";
+import FuncDecl from "../../src/ast/FuncDecl";
+import {InterfaceDecl} from "../../src/ast/InterfaceDecl";
+import ReturnDecl from "../../src/ast/ReturnDecl";
+
+describe('ImportStringBuilder ClassDecl tests', function() {
+
+    it('should build an import string body for a class that imports from the same directory', () => {
+        let pathTable: PathTable = PathTable.getInstance();
+        pathTable.addTypePath("Animal", "./src/animals/animal.ts")
+        pathTable.addTypePath("Age", "./src/animals/age.ts");
+
+        let animalClass = new ClassDecl("./src/animals");
+        animalClass.className = "Animal";
+
+        let animalFields = new FieldDecl();
+        let animalFieldVarList = new VarList();
+        animalFieldVarList.addPair("age", "Age");
+        animalFields.fields = animalFieldVarList;
+
+        animalClass.functions = [];
+        animalClass.fields = [animalFields];
+
+        expect(ImportStringBuilder.getImportsString(animalClass)).to.equal(
+            "import {Age} from \"./age.ts\";\n");
+    });
+
+    it('should build an import string body for a class that imports from other sub-directory trees', () => {
+        let pathTable: PathTable = PathTable.getInstance();
+        pathTable.addTypePath("Animal", "./src/animals/animal.ts")
+        pathTable.addTypePath("Age", "./src/animals/age.ts");
+        pathTable.addTypePath("Diet", "./src/animals/diet.ts");
+        pathTable.addTypePath("Blarg", "./test/util/blarg.ts");
+
+        let animalClass = new ClassDecl("./src/animals");
+        animalClass.className = "Animal";
+
+        let animalFields = new FieldDecl();
+        let animalFieldVarList = new VarList();
+        animalFieldVarList.addPair("age", "Age");
+        animalFieldVarList.addPair("diet", "Diet");
+        animalFieldVarList.addPair("blarg", "Blarg");
+        animalFields.fields = animalFieldVarList;
+
+        animalClass.functions = [];
+        animalClass.fields = [animalFields];
+
+        expect(ImportStringBuilder.getImportsString(animalClass)).to.equal(
+            "import {Age} from \"./age.ts\";\n" +
+            "import {Diet} from \"./diet.ts\";\n" +
+            "import {Blarg} from \"../../test/util/blarg.ts\";\n");
+    });
+
+    it('should build an import string body for a class that imports using fields, function params and function return', () => {
+        let pathTable: PathTable = PathTable.getInstance();
+        pathTable.addTypePath("Animal", "./src/animals/animal.ts")
+        pathTable.addTypePath("Age", "./src/animals/age.ts");
+        pathTable.addTypePath("Diet", "./src/animals/diet.ts");
+        pathTable.addTypePath("Blarg", "./test/util/blarg.ts");
+        pathTable.addTypePath("Owner", "./src/humans/owner.ts");
+        pathTable.addTypePath("Firetruck", "./test/util/firetruck.ts");
+
+        let animalClass = new ClassDecl("./src/animals");
+        animalClass.className = "Animal";
+
+        let animalFields = new FieldDecl();
+        let animalFieldVarList = new VarList();
+        animalFieldVarList.addPair("age", "Age");
+        animalFieldVarList.addPair("diet", "Diet");
+        animalFieldVarList.addPair("blarg", "Blarg");
+        animalFields.fields = animalFieldVarList;
+
+        let animalFunc = new FuncDecl();
+        let animalParamVarList = new VarList();
+        let animalFuncReturn = new ReturnDecl();
+        animalFuncReturn.returnType = "Firetruck";
+        animalParamVarList.addPair("owner", "Owner");
+        animalFunc.params = animalParamVarList;
+        animalFunc.returnDecl = animalFuncReturn;
+
+        animalClass.functions = [animalFunc];
+        animalClass.fields = [animalFields];
+
+        expect(ImportStringBuilder.getImportsString(animalClass)).to.equal(
+            "import {Age} from \"./age.ts\";\n" +
+            "import {Diet} from \"./diet.ts\";\n" +
+            "import {Blarg} from \"../../test/util/blarg.ts\";\n" +
+            "import {Owner} from \"../humans/owner.ts\";\n" +
+            "import {Firetruck} from \"../../test/util/firetruck.ts\";\n");
+    });
+
+    it('should build an import string body for a deeply nested class', () => {
+        let pathTable: PathTable = PathTable.getInstance();
+        pathTable.addTypePath("Animal", "./src/animals/onelevel/onemorelevel/animal.ts")
+        pathTable.addTypePath("Age", "./src/animals/age.ts");
+        pathTable.addTypePath("Diet", "./src/animals/diet.ts");
+        pathTable.addTypePath("Blarg", "./test/util/blarg.ts");
+        pathTable.addTypePath("Owner", "./src/humans/owner.ts");
+        pathTable.addTypePath("Firetruck", "./test/util/firetruck.ts");
+
+        let animalClass = new ClassDecl("./src/animals/onelevel/onemorelevel");
+        animalClass.className = "Animal";
+
+        let animalFields = new FieldDecl();
+        let animalFieldVarList = new VarList();
+        animalFieldVarList.addPair("age", "Age");
+        animalFieldVarList.addPair("diet", "Diet");
+        animalFieldVarList.addPair("blarg", "Blarg");
+        animalFields.fields = animalFieldVarList;
+
+        let animalFunc = new FuncDecl();
+        let animalParamVarList = new VarList();
+        let animalFuncReturn = new ReturnDecl();
+        animalFuncReturn.returnType = "Firetruck";
+        animalParamVarList.addPair("owner", "Owner");
+        animalFunc.params = animalParamVarList;
+        animalFunc.returnDecl = animalFuncReturn;
+
+        animalClass.functions = [animalFunc];
+        animalClass.fields = [animalFields];
+
+        expect(ImportStringBuilder.getImportsString(animalClass)).to.equal(
+            "import {Age} from \"../../age.ts\";\n" +
+            "import {Diet} from \"../../diet.ts\";\n" +
+            "import {Blarg} from \"../../../../test/util/blarg.ts\";\n" +
+            "import {Owner} from \"../../../humans/owner.ts\";\n" +
+            "import {Firetruck} from \"../../../../test/util/firetruck.ts\";\n");
+    });
+});
+
+describe('ImportStringBuilder InterfaceDecl tests', function() {
+
+    it('should build an import string body for a interface that imports from the same directory', () => {
+        let pathTable: PathTable = PathTable.getInstance();
+        pathTable.addTypePath("Animal", "./src/animals/animal.ts")
+        pathTable.addTypePath("Age", "./src/animals/age.ts");
+
+        let animalInterface = new InterfaceDecl("./src/animals");
+        animalInterface.interfaceName = "Animal";
+
+        let animalFields = new FieldDecl();
+        let animalFieldVarList = new VarList();
+        animalFieldVarList.addPair("age", "Age");
+        animalFields.fields = animalFieldVarList;
+
+        animalInterface.functions = [];
+        animalInterface.fieldDecl = animalFields;
+
+        expect(ImportStringBuilder.getImportsString(animalInterface)).to.equal(
+            "import {Age} from \"./age.ts\";\n");
+    });
+
+    it('should build an import string body for a interface that imports from other sub-directory trees', () => {
+        let pathTable: PathTable = PathTable.getInstance();
+        pathTable.addTypePath("Animal", "./src/animals/animal.ts")
+        pathTable.addTypePath("Age", "./src/animals/age.ts");
+        pathTable.addTypePath("Diet", "./src/animals/diet.ts");
+        pathTable.addTypePath("Blarg", "./test/util/blarg.ts");
+
+        let animalInterface = new InterfaceDecl("./src/animals");
+        animalInterface.interfaceName = "Animal";
+
+        let animalFields = new FieldDecl();
+        let animalFieldVarList = new VarList();
+        animalFieldVarList.addPair("age", "Age");
+        animalFieldVarList.addPair("diet", "Diet");
+        animalFieldVarList.addPair("blarg", "Blarg");
+        animalFields.fields = animalFieldVarList;
+
+        animalInterface.functions = [];
+        animalInterface.fieldDecl = animalFields;
+
+        expect(ImportStringBuilder.getImportsString(animalInterface)).to.equal(
+            "import {Age} from \"./age.ts\";\n" +
+            "import {Diet} from \"./diet.ts\";\n" +
+            "import {Blarg} from \"../../test/util/blarg.ts\";\n");
+    });
+
+    it('should build an import string body for a interface that imports using fields, function params and function return', () => {
+        let pathTable: PathTable = PathTable.getInstance();
+        pathTable.addTypePath("Animal", "./src/animals/animal.ts")
+        pathTable.addTypePath("Age", "./src/animals/age.ts");
+        pathTable.addTypePath("Diet", "./src/animals/diet.ts");
+        pathTable.addTypePath("Blarg", "./test/util/blarg.ts");
+        pathTable.addTypePath("Owner", "./src/humans/owner.ts");
+        pathTable.addTypePath("Firetruck", "./test/util/firetruck.ts");
+
+        let animalInterface = new InterfaceDecl("./src/animals");
+        animalInterface.interfaceName = "Animal";
+
+        let animalFields = new FieldDecl();
+        let animalFieldVarList = new VarList();
+        animalFieldVarList.addPair("age", "Age");
+        animalFieldVarList.addPair("diet", "Diet");
+        animalFieldVarList.addPair("blarg", "Blarg");
+        animalFields.fields = animalFieldVarList;
+
+        let animalFunc = new FuncDecl();
+        let animalParamVarList = new VarList();
+        let animalFuncReturn = new ReturnDecl();
+        animalFuncReturn.returnType = "Firetruck";
+        animalParamVarList.addPair("owner", "Owner");
+        animalFunc.params = animalParamVarList;
+        animalFunc.returnDecl = animalFuncReturn;
+
+        animalInterface.functions = [animalFunc];
+        animalInterface.fieldDecl = animalFields;
+
+        expect(ImportStringBuilder.getImportsString(animalInterface)).to.equal(
+            "import {Age} from \"./age.ts\";\n" +
+            "import {Diet} from \"./diet.ts\";\n" +
+            "import {Blarg} from \"../../test/util/blarg.ts\";\n" +
+            "import {Owner} from \"../humans/owner.ts\";\n" +
+            "import {Firetruck} from \"../../test/util/firetruck.ts\";\n");
+    });
+});

--- a/test/util/ImportStringBuilder.spec.ts
+++ b/test/util/ImportStringBuilder.spec.ts
@@ -7,6 +7,8 @@ import {VarList} from "../../src/ast/VarList";
 import FuncDecl from "../../src/ast/FuncDecl";
 import {InterfaceDecl} from "../../src/ast/InterfaceDecl";
 import ReturnDecl from "../../src/ast/ReturnDecl";
+import {ExtendsDecl} from "../../src/ast/ExtendsDecl";
+import {ImplementsDecl} from "../../src/ast/ImplementsDecl";
 
 describe('ImportStringBuilder ClassDecl tests', function() {
 
@@ -56,14 +58,17 @@ describe('ImportStringBuilder ClassDecl tests', function() {
             "import {Blarg} from \"../../test/util/blarg.ts\";\n");
     });
 
-    it('should build an import string body for a class that imports using fields, function params and function return', () => {
+    it('should build an import string body for a class that imports using fields, functions and inheritance', () => {
         let pathTable: PathTable = PathTable.getInstance();
-        pathTable.addTypePath("Animal", "./src/animals/animal.ts")
+        pathTable.addTypePath("Animal", "./src/animals/animal.ts");
         pathTable.addTypePath("Age", "./src/animals/age.ts");
         pathTable.addTypePath("Diet", "./src/animals/diet.ts");
         pathTable.addTypePath("Blarg", "./test/util/blarg.ts");
         pathTable.addTypePath("Owner", "./src/humans/owner.ts");
         pathTable.addTypePath("Firetruck", "./test/util/firetruck.ts");
+        pathTable.addTypePath("LivingThing", "./src/livingthing.ts");
+        pathTable.addTypePath("Being", "./src/being.ts");
+
 
         let animalClass = new ClassDecl("./src/animals");
         animalClass.className = "Animal";
@@ -83,6 +88,12 @@ describe('ImportStringBuilder ClassDecl tests', function() {
         animalFunc.params = animalParamVarList;
         animalFunc.returnDecl = animalFuncReturn;
 
+        animalClass.extendsNodes = new ExtendsDecl();
+        animalClass.extendsNodes.parentName = "LivingThing";
+
+        animalClass.implementsNodes = new ImplementsDecl();
+        animalClass.implementsNodes.parentNames = ["Being"];
+
         animalClass.functions = [animalFunc];
         animalClass.fields = [animalFields];
 
@@ -91,7 +102,9 @@ describe('ImportStringBuilder ClassDecl tests', function() {
             "import {Diet} from \"./diet.ts\";\n" +
             "import {Blarg} from \"../../test/util/blarg.ts\";\n" +
             "import {Owner} from \"../humans/owner.ts\";\n" +
-            "import {Firetruck} from \"../../test/util/firetruck.ts\";\n");
+            "import {Firetruck} from \"../../test/util/firetruck.ts\";\n" +
+            "import {LivingThing} from \"../livingthing.ts\";\n" +
+            "import {Being} from \"../being.ts\";\n");
     });
 
     it('should build an import string body for a deeply nested class', () => {
@@ -181,7 +194,7 @@ describe('ImportStringBuilder InterfaceDecl tests', function() {
             "import {Blarg} from \"../../test/util/blarg.ts\";\n");
     });
 
-    it('should build an import string body for a interface that imports using fields, function params and function return', () => {
+    it('should build an import string body for a interface that imports using fields, functions and inheritance', () => {
         let pathTable: PathTable = PathTable.getInstance();
         pathTable.addTypePath("Animal", "./src/animals/animal.ts")
         pathTable.addTypePath("Age", "./src/animals/age.ts");
@@ -189,6 +202,7 @@ describe('ImportStringBuilder InterfaceDecl tests', function() {
         pathTable.addTypePath("Blarg", "./test/util/blarg.ts");
         pathTable.addTypePath("Owner", "./src/humans/owner.ts");
         pathTable.addTypePath("Firetruck", "./test/util/firetruck.ts");
+        pathTable.addTypePath("LivingThing", "./src/livingthing.ts");
 
         let animalInterface = new InterfaceDecl("./src/animals");
         animalInterface.interfaceName = "Animal";
@@ -211,11 +225,15 @@ describe('ImportStringBuilder InterfaceDecl tests', function() {
         animalInterface.functions = [animalFunc];
         animalInterface.fieldDecl = animalFields;
 
+        animalInterface.extendsNodes = new ExtendsDecl();
+        animalInterface.extendsNodes.parentName = "LivingThing";
+
         expect(ImportStringBuilder.getImportsString(animalInterface)).to.equal(
             "import {Age} from \"./age.ts\";\n" +
             "import {Diet} from \"./diet.ts\";\n" +
             "import {Blarg} from \"../../test/util/blarg.ts\";\n" +
             "import {Owner} from \"../humans/owner.ts\";\n" +
-            "import {Firetruck} from \"../../test/util/firetruck.ts\";\n");
+            "import {Firetruck} from \"../../test/util/firetruck.ts\";\n" +
+            "import {LivingThing} from \"../livingthing.ts\";\n");
     });
 });


### PR DESCRIPTION
## Done:
- Create new ImportStringBuilder util class - when passed a ClassDecl or an ImportDecl, gives an import string body.
e.g.
```
import {VarList} from "../ast/VarList";
import {PathTable} from "./PathTable";
import {ClassDecl} from "../ast/ClassDecl";
```

- Create PathTable - a singleton that carries the paths to any type.