### PR TITLE
add check for field modifier in Interface (can't be anything but public)

### DIFF
--- a/src/ast/FieldDecl.ts
+++ b/src/ast/FieldDecl.ts
@@ -1,6 +1,7 @@
 import {VarList} from "./VarList";
-import {AstNode} from "./AstNode";
 import {ParseError, Tokenizer} from "../util/Tokenizer";
+import {ValidationError} from "./errors/ASTErrors";
+import {AstNode} from "./AstNode";
 
 /**
  * Represents a field declaration in the TypeScript DSL.
@@ -12,6 +13,7 @@ export class FieldDecl extends AstNode {
 
     fields: VarList;
     modifier: string;
+    isInterfaceField: boolean = false;
     generateGetter: boolean = false;
     generateSetter: boolean = false;
 
@@ -53,6 +55,9 @@ export class FieldDecl extends AstNode {
     }
 
     public typeCheck(): void {
+        if(this.isInterfaceField && this.modifier !== "public") {
+            throw new ValidationError("Interfaces cannot have non-public fields");
+        }
         this.fields.typeCheck();
     }
 }

--- a/src/ast/InterfaceDecl.ts
+++ b/src/ast/InterfaceDecl.ts
@@ -33,8 +33,8 @@ export class InterfaceDecl extends Content {
         }
 
         if(context.getCurrentLineTabLevel() > indentLevel && context.checkToken("fields")) {
-            // TODO: how do we want to handle if someone tries to declare private fields in an interface?
             this.fieldDecl = new FieldDecl();
+            this.fieldDecl.isInterfaceField = true;
             this.fieldDecl.parse(context);
         }
 
@@ -57,8 +57,13 @@ export class InterfaceDecl extends Content {
     }
 
     public typeCheck(): void {
-        this.extendsNodes.typeCheck();
-        this.fieldDecl.typeCheck();
+        if(this.extendsNodes) {
+            this.extendsNodes.typeCheck();
+        }
+        if(this.fieldDecl) {
+            this.fieldDecl.typeCheck();
+        }
+
         this.functions.forEach((funcDecl: FuncDecl) => funcDecl.typeCheck());
     }
 

--- a/src/ast/errors/ASTErrors.ts
+++ b/src/ast/errors/ASTErrors.ts
@@ -1,0 +1,6 @@
+export class ValidationError extends Error {
+    constructor(...args: any[]) {
+        super(...args);
+        Error.captureStackTrace(this, ValidationError);
+    }
+}

--- a/test/ast/InterfaceDecl.spec.ts
+++ b/test/ast/InterfaceDecl.spec.ts
@@ -2,8 +2,9 @@ import { expect } from "chai";
 import {Tokenizer} from "../../src/util/Tokenizer";
 import {InterfaceDecl} from "../../src/ast/InterfaceDecl";
 import {TypeTable} from "../../src/ast/symbols/TypeTable";
+import {ValidationError} from "../../src/ast/errors/ASTErrors";
 
-describe("ClassDecl parse test", () => {
+describe("InterfaceDecl parse test", () => {
     it("parses single-line, simple interface definition", () => {
         let typeTable : TypeTable = TypeTable.getInstance();
         expect(typeTable.table.size).to.equal(4);
@@ -37,11 +38,39 @@ describe("ClassDecl parse test", () => {
         expect(intDec.fieldDecl).to.be.undefined;
         expect(intDec.functions.length).to.equal(2);
     });
+});
 
+describe("InterfaceDecl evaluate test", () => {
     it("should write a complex interface definition to disk", () => {
         let tokenizer : Tokenizer = new Tokenizer("interfaceDeclComplex.txt", "./test/testFiles");
         let intDec : InterfaceDecl = new InterfaceDecl("./codegen/test");
         intDec.parse(tokenizer);
         intDec.evaluate();
     });
+});
+
+describe("InterfaceDecl typeCheck test", () => {
+    it("throws a validation error when the modifier for an interface is not public", () => {
+        let tokenizer : Tokenizer = new Tokenizer("interfaceDeclInvalidFieldMod.txt", "./test/testFiles");
+        let intDec : InterfaceDecl = new InterfaceDecl(".");
+        intDec.parse(tokenizer);
+        expect(() => {intDec.typeCheck()}).to.throw(ValidationError);
+    });
+
+    it("successfully validates an interface declaration with private fields", () => {
+        let tokenizer : Tokenizer = new Tokenizer("interfaceDeclWithFields.txt", "./test/testFiles");
+        let intDec : InterfaceDecl = new InterfaceDecl(".");
+        intDec.parse(tokenizer);
+        expect(() => {intDec.typeCheck()}).to.not.throw(ValidationError);
+
+    });
+
+    it("successfully validates an interface declaration with no fields", () => {
+        let tokenizer : Tokenizer = new Tokenizer("interfaceDeclComplex.txt", "./test/testFiles");
+        let intDec : InterfaceDecl = new InterfaceDecl(".");
+        intDec.parse(tokenizer);
+        expect(() => {intDec.typeCheck()}).to.not.throw(ValidationError);
+
+    });
+
 });

--- a/test/testFiles/interfaceDeclInvalidFieldMod.txt
+++ b/test/testFiles/interfaceDeclInvalidFieldMod.txt
@@ -1,0 +1,10 @@
+interface TransitLine
+    fields private [ number dayOfWeek, number hour, number minute ]
+    function public getNumberOfStops
+        params [ ]
+        comments [ "Returns the number of stops in the transit line" ]
+        returns number
+    function public getRoute
+        params [ ]
+        comments [ "Returns the street names of transit route" ]
+        returns string

--- a/test/testFiles/interfaceDeclWithFields.txt
+++ b/test/testFiles/interfaceDeclWithFields.txt
@@ -1,0 +1,10 @@
+interface TransitLine
+    fields public [ number dayOfWeek, number hour, number minute ]
+    function public getNumberOfStops
+        params [ ]
+        comments [ "Returns the number of stops in the transit line" ]
+        returns number
+    function public getRoute
+        params [ ]
+        comments [ "Returns the street names of transit route" ]
+        returns string


### PR DESCRIPTION
- Validate that a field modifier is not private/protected (put in typeCheck, but we can move it if we want to put this functionality elsewhere) 