### PR TITLE
update class and interface decl to throw errors with invalid inputs

### DIFF
--- a/src/ast/ClassDecl.ts
+++ b/src/ast/ClassDecl.ts
@@ -45,9 +45,7 @@ export class ClassDecl extends Content {
             this.extendsNodes.parse(context);
         }
 
-        if(!context.isStartOfLine()) {
-            throw new ParseError("New line missing from " + this.className + " class");
-        }
+        context.checkStartOfLine();
 
         if(context.getCurrentLineTabLevel() > indentLevel && context.checkToken("comments")) {
             this.comments = new CommentDecl();
@@ -55,16 +53,17 @@ export class ClassDecl extends Content {
         }
 
         while(context.getCurrentLineTabLevel() > indentLevel && context.checkToken("fields")) {
+            context.checkStartOfLine();
             let field: FieldDecl = new FieldDecl();
             field.parse(context);
             if (field.generateGetter) {
-                field.fields.nameTypeMap.forEach((type: string, name: string) => {
+                field.fields.nameTypeMap.forEach((name: string, type: string) => {
                     this.functions.push(this.createGetter(name, type));
                 });
 
             }
             if (field.generateSetter) {
-                field.fields.nameTypeMap.forEach((type: string, name: string) => {
+                field.fields.nameTypeMap.forEach((name: string, type: string) => {
                     this.functions.push(this.createSetter(name, type));
                 });
             }
@@ -72,6 +71,7 @@ export class ClassDecl extends Content {
         }
 
         while(context.getCurrentLineTabLevel() > indentLevel && context.checkToken("function")) {
+            context.checkStartOfLine();
             let func: FuncDecl = new FuncDecl();
             func.parse(context);
             this.functions.push(func);

--- a/src/ast/ClassDecl.ts
+++ b/src/ast/ClassDecl.ts
@@ -57,13 +57,13 @@ export class ClassDecl extends Content {
             let field: FieldDecl = new FieldDecl();
             field.parse(context);
             if (field.generateGetter) {
-                field.fields.nameTypeMap.forEach((name: string, type: string) => {
+                field.fields.nameTypeMap.forEach((type: string, name: string) => {
                     this.functions.push(this.createGetter(name, type));
                 });
 
             }
             if (field.generateSetter) {
-                field.fields.nameTypeMap.forEach((name: string, type: string) => {
+                field.fields.nameTypeMap.forEach((type: string, name: string) => {
                     this.functions.push(this.createSetter(name, type));
                 });
             }

--- a/src/ast/ClassDecl.ts
+++ b/src/ast/ClassDecl.ts
@@ -4,7 +4,7 @@ import {ExtendsDecl} from "./ExtendsDecl";
 import {ImplementsDecl} from "./ImplementsDecl";
 import CommentDecl from "./CommentDecl";
 import FuncDecl from "./FuncDecl";
-import {Tokenizer} from "../util/Tokenizer";
+import {ParseError, Tokenizer} from "../util/Tokenizer";
 
 /**
  * Represents a Class a TypeScript project may have.
@@ -40,6 +40,10 @@ export class ClassDecl extends Content {
             this.extendsNodes.parse(context);
         }
 
+        if(!context.isStartOfLine()) {
+            throw new ParseError("New line missing from " + this.className + " class");
+        }
+
         if(context.getCurrentLineTabLevel() > indentLevel && context.checkToken("comments")) {
             this.comments = new CommentDecl();
             this.comments.parse(context);
@@ -55,6 +59,10 @@ export class ClassDecl extends Content {
             let func: FuncDecl = new FuncDecl();
             func.parse(context);
             this.functions.push(func);
+        }
+
+        if(context.getCurrentLineTabLevel() > indentLevel) {
+            throw new ParseError(`Invalid keyword: ${context.getNext()}  found under ${this.className} class`);
         }
 
         this.typeTable.addClass(this.className);

--- a/src/ast/InterfaceDecl.ts
+++ b/src/ast/InterfaceDecl.ts
@@ -31,14 +31,14 @@ export class InterfaceDecl extends Content {
             this.extendsNodes.parse(context);
         }
 
-        if(!context.isStartOfLine()) {
-            throw new ParseError("New line missing from " + this.interfaceName + " interface");
-        }
+        context.checkStartOfLine();
 
         if(context.getCurrentLineTabLevel() > indentLevel && context.checkToken("comments")) {
             this.comments = new CommentDecl();
             this.comments.parse(context);
         }
+
+        context.checkStartOfLine();
 
         if(context.getCurrentLineTabLevel() > indentLevel && context.checkToken("fields")) {
             this.fieldDecl = new FieldDecl();
@@ -60,6 +60,7 @@ export class InterfaceDecl extends Content {
         }
 
         while(context.getCurrentLineTabLevel() > indentLevel && context.checkToken("function")) {
+            context.checkStartOfLine();
             let func: FuncDecl = new FuncDecl();
             func.parse(context);
             this.functions.push(func);

--- a/src/ast/InterfaceDecl.ts
+++ b/src/ast/InterfaceDecl.ts
@@ -3,7 +3,7 @@ import {ExtendsDecl} from "./ExtendsDecl";
 import {FieldDecl} from "./FieldDecl";
 import CommentDecl from "./CommentDecl";
 import FuncDecl from "./FuncDecl";
-import {Tokenizer} from "../util/Tokenizer";
+import {ParseError, Tokenizer} from "../util/Tokenizer";
 
 /**
  * Represents an Interface a TypeScript project may have.
@@ -27,6 +27,10 @@ export class InterfaceDecl extends Content {
             this.extendsNodes.parse(context);
         }
 
+        if(!context.isStartOfLine()) {
+            throw new ParseError("New line missing from " + this.interfaceName + " interface");
+        }
+
         if(context.getCurrentLineTabLevel() > indentLevel && context.checkToken("comments")) {
             this.comments = new CommentDecl();
             this.comments.parse(context);
@@ -42,6 +46,10 @@ export class InterfaceDecl extends Content {
             let func: FuncDecl = new FuncDecl();
             func.parse(context);
             this.functions.push(func);
+        }
+
+        if(context.getCurrentLineTabLevel() > indentLevel) {
+            throw new ParseError(`Invalid keyword: ${context.getNext()}  found under ${this.interfaceName} interface`);
         }
 
         this.typeTable.addInterface(this.interfaceName);

--- a/src/util/Tokenizer.ts
+++ b/src/util/Tokenizer.ts
@@ -122,6 +122,7 @@ export class Tokenizer {
             // 5. split on reservedword
             this.tokens.push(line.split(Tokenizer.reservedTokenWord).filter((str) => str !==''));
         });
+        console.log(this.tokens);
     }
 
     /**
@@ -211,10 +212,11 @@ export class Tokenizer {
     public getAndCheckNext(regexp: string): string {
         let next = this.getNext();
         if(!RegExp(regexp).test(next)) {
-            throw new TokenizerError(next + " did not match regex value " + regexp);
+            throw new TokenizerError(`${next} is an invalid token in line ${this.currentToken.arr + 1}`);
         }
         return next;
     }
+
     /**
      * Gets the indentation level of the current line, if out of bounds, returns 0
      * @returns number  indentation level of current line
@@ -224,5 +226,13 @@ export class Tokenizer {
             return parseInt(this.tokens[this.currentToken.arr][0].replace(/\D/g, ''));
         }
         return 0;
+    }
+
+    /**
+     * Determines whether the current token position is at the start of a new line
+     * @returns boolean  indicating whether next token is from a new line
+     */
+    public isStartOfLine(): boolean {
+        return this.currentToken.pos === 1;
     }
 }

--- a/src/util/Tokenizer.ts
+++ b/src/util/Tokenizer.ts
@@ -228,6 +228,12 @@ export class Tokenizer {
         return 0;
     }
 
+    public checkStartOfLine(): void {
+        if(!this.isStartOfLine()) {
+            throw new TokenizerError(`New line missing in line ${this.currentToken.arr + 1} before: ${this.getNext()}`);
+        }
+    }
+
     /**
      * Determines whether the current token position is at the start of a new line
      * @returns boolean  indicating whether next token is from a new line

--- a/test/ast/ClassDecl.spec.ts
+++ b/test/ast/ClassDecl.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from "chai";
 import {ClassDecl} from "../../src/ast/ClassDecl";
-import {ParseError, Tokenizer} from "../../src/util/Tokenizer";
+import {ParseError, Tokenizer, TokenizerError} from "../../src/util/Tokenizer";
 import {TypeCheckError, TypeTable} from "../../src/ast/symbols/TypeTable";
 import * as nodeFs from "fs-extra";
 
@@ -54,7 +54,13 @@ describe("ClassDecl parse test", () => {
     it("throws a parse error when class definition includes extends after implements", () => {
         let tokenizer : Tokenizer = new Tokenizer("classDeclInvalidFirstLine.txt", "./test/testFiles");
         let classDec : ClassDecl = new ClassDecl(DUMMY_ROOT_DIR);
-        expect(() => {classDec.parse(tokenizer)}).to.throw(ParseError);
+        expect(() => {classDec.parse(tokenizer)}).to.throw(TokenizerError);
+    });
+
+    it("throws a parse error when class definition field decl with missing new line", () => {
+        let tokenizer : Tokenizer = new Tokenizer("classDeclInvalidMergedLines.txt", "./test/testFiles");
+        let classDec : ClassDecl = new ClassDecl(DUMMY_ROOT_DIR);
+        expect(() => {classDec.parse(tokenizer)}).to.throw(TokenizerError);
     });
 
     it("throws a parse error when there is an invalid value inside the class", () => {

--- a/test/ast/ClassDecl.spec.ts
+++ b/test/ast/ClassDecl.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from "chai";
 import {ClassDecl} from "../../src/ast/ClassDecl";
-import {Tokenizer} from "../../src/util/Tokenizer";
+import {ParseError, Tokenizer} from "../../src/util/Tokenizer";
 import {TypeCheckError, TypeTable} from "../../src/ast/symbols/TypeTable";
 import * as nodeFs from "fs-extra";
 
@@ -51,6 +51,22 @@ describe("ClassDecl parse test", () => {
 
     });
 
+    it("throws a parse error when class definition includes extends after implements", () => {
+        let tokenizer : Tokenizer = new Tokenizer("classDeclInvalidFirstLine.txt", "./test/testFiles");
+        let classDec : ClassDecl = new ClassDecl(DUMMY_ROOT_DIR);
+        expect(() => {classDec.parse(tokenizer)}).to.throw(ParseError);
+    });
+
+    it("throws a parse error when there is an invalid value inside the class", () => {
+        let tokenizer : Tokenizer = new Tokenizer("classDeclInvalidInputs.txt", "./test/testFiles");
+        let classDec : ClassDecl = new ClassDecl(DUMMY_ROOT_DIR);
+        expect(() => {classDec.parse(tokenizer)}).to.throw(ParseError);
+    });
+});
+
+describe("ClassDecl type check test", () => {
+    const DUMMY_ROOT_DIR: string = ".";
+
     it("should throw a TypeCheckError when it attempts to extend a undeclared class", () => {
         let tokenizer : Tokenizer = new Tokenizer("classDeclSimple.txt", "./test/testFiles");
         let classDec : ClassDecl = new ClassDecl(DUMMY_ROOT_DIR);
@@ -67,6 +83,7 @@ describe("ClassDecl parse test", () => {
         TypeTable.getInstance().addClass("TimeClass");
         classDec.typeCheck();
     });
+
 });
 
 describe ("ClassDecl evaluate test", () => {

--- a/test/ast/InterfaceDecl.spec.ts
+++ b/test/ast/InterfaceDecl.spec.ts
@@ -1,5 +1,5 @@
 import { expect } from "chai";
-import {Tokenizer} from "../../src/util/Tokenizer";
+import {ParseError, Tokenizer} from "../../src/util/Tokenizer";
 import {InterfaceDecl} from "../../src/ast/InterfaceDecl";
 import {TypeTable} from "../../src/ast/symbols/TypeTable";
 import {ValidationError} from "../../src/ast/errors/ASTErrors";
@@ -23,10 +23,9 @@ describe("InterfaceDecl parse test", () => {
     });
 
     it("throws an error parsing invalid interface definition", () => {
-        // TODO: implement this test case may require changes to how we tokenize... (does not currently throw error)
         let tokenizer : Tokenizer = new Tokenizer("interfaceSimpleInvalid.txt", "./test/testFiles");
         let intDec : InterfaceDecl = new InterfaceDecl(".");
-        intDec.parse(tokenizer);
+        expect(() => {intDec.parse(tokenizer)}).to.throw(ParseError);
     });
 
     it("parses complex interface definition", () => {
@@ -37,6 +36,13 @@ describe("InterfaceDecl parse test", () => {
         expect(intDec.comments).to.be.undefined;
         expect(intDec.fieldDecl).to.be.undefined;
         expect(intDec.functions.length).to.equal(2);
+    });
+
+    it("throws a ParseError with invalid line", () => {
+        let tokenizer : Tokenizer = new Tokenizer("interfaceInvalidInput.txt", "./test/testFiles");
+        let intDec : InterfaceDecl = new InterfaceDecl(".");
+        expect(() => {intDec.parse(tokenizer)}).to.throw(ParseError);
+
     });
 });
 

--- a/test/ast/InterfaceDecl.spec.ts
+++ b/test/ast/InterfaceDecl.spec.ts
@@ -1,5 +1,5 @@
 import { expect } from "chai";
-import {ParseError, Tokenizer} from "../../src/util/Tokenizer";
+import {ParseError, Tokenizer, TokenizerError} from "../../src/util/Tokenizer";
 import {InterfaceDecl} from "../../src/ast/InterfaceDecl";
 import {TypeTable} from "../../src/ast/symbols/TypeTable";
 import {ValidationError} from "../../src/ast/errors/ASTErrors";
@@ -25,7 +25,7 @@ describe("InterfaceDecl parse test", () => {
     it("throws an error parsing invalid interface definition", () => {
         let tokenizer : Tokenizer = new Tokenizer("interfaceSimpleInvalid.txt", "./test/testFiles");
         let intDec : InterfaceDecl = new InterfaceDecl(".");
-        expect(() => {intDec.parse(tokenizer)}).to.throw(ParseError);
+        expect(() => {intDec.parse(tokenizer)}).to.throw(TokenizerError);
     });
 
     it("parses complex interface definition", () => {

--- a/test/testFiles/classDeclInvalidFirstLine.txt
+++ b/test/testFiles/classDeclInvalidFirstLine.txt
@@ -1,0 +1,12 @@
+class Time extends TimeClass implements ITime, DateTime
+    comments [ "This is the time class" ]
+    fields private [ number dayOfWeek, number hour, number minute ]
+        generate getters
+        generate setters
+    fields public [ number date ]
+        generate getters
+    function public getDate
+        params [ string id, string content, string kind ]
+        comments [ "creates a new Time object from given date",
+            "{param} date - date object to parse time object from" ]
+        returns string

--- a/test/testFiles/classDeclInvalidInputs.txt
+++ b/test/testFiles/classDeclInvalidInputs.txt
@@ -1,0 +1,12 @@
+class Time implements ITime, DateTime extends TimeClass
+    comments [ "This is the time class" ]
+    fields private [ number dayOfWeek, number hour, number minute ]
+        generate getters
+        generate setters
+    fieldrandomtypo public [ number date ]
+        generate getters
+    function public getDate
+        params [ string id, string content, string kind ]
+        comments [ "creates a new Time object from given date",
+            "{param} date - date object to parse time object from" ]
+        returns string

--- a/test/testFiles/classDeclInvalidMergedLines.txt
+++ b/test/testFiles/classDeclInvalidMergedLines.txt
@@ -1,0 +1,9 @@
+class Time extends TimeClass
+    comments [ "This is the time class" ]
+    fields private [ number dayOfWeek, number hour, number minute ] fields public [ number date ]
+        generate getters
+    function public getDate
+        params [ string id, string content, string kind ]
+        comments [ "creates a new Time object from given date",
+            "{param} date - date object to parse time object from" ]
+        returns string

--- a/test/testFiles/interfaceInvalidInput.txt
+++ b/test/testFiles/interfaceInvalidInput.txt
@@ -1,0 +1,10 @@
+interface TransitLine
+    fields public [ number dayOfWeek, number hour, number minute ]
+    function public getNumberOfStops
+        params [ ] rubbish
+        comments [ "Returns the number of stops in the transit line" ]
+        returns number
+    function public getRoute
+        params [ ]
+        comments [ "Returns the street names of transit route" ]
+        returns string


### PR DESCRIPTION
- Throw ParseError when ClassDecl/ InterfaceDecl parse comes across incorrect input.
- Added tests for these cases
- Added isStartOfLine method to Tokenizer to allow for new line checks
- Updated getAndCheckNext Error to include the line number in the error message