### PR TITLE
Add import strings to Class and Interface Evaluation

### DIFF
--- a/src/ast/ClassDecl.ts
+++ b/src/ast/ClassDecl.ts
@@ -59,7 +59,7 @@ export class ClassDecl extends Content {
         }
 
         this.typeTable.addClass(this.className);
-        this.pathTable.addTypePath(this.className, this.getAbsolutePath());
+        this.pathTable.addTypePath(this.className, this.getImportPath());
 
         return this;
     }
@@ -77,6 +77,10 @@ export class ClassDecl extends Content {
         }
         this.fields.forEach((fieldDecl: FieldDecl) => fieldDecl.typeCheck());
         this.functions.forEach((funcDecl: FuncDecl) => funcDecl.typeCheck());
+    }
+
+    public getImportPath(): string {
+        return `${this.parentPath}/${this.className}`;
     }
 
     public getAbsolutePath(): string {

--- a/src/ast/ClassDecl.ts
+++ b/src/ast/ClassDecl.ts
@@ -5,6 +5,7 @@ import {ImplementsDecl} from "./ImplementsDecl";
 import CommentDecl from "./CommentDecl";
 import FuncDecl from "./FuncDecl";
 import {Tokenizer} from "../util/Tokenizer";
+import {ImportStringBuilder} from "../util/ImportStringBuilder";
 
 /**
  * Represents a Class a TypeScript project may have.
@@ -64,8 +65,10 @@ export class ClassDecl extends Content {
     }
 
     public evaluate(): any {
+        const importStr: string = ImportStringBuilder.getImportsString(this);
         const tsNodeStr: string = this.printer.tsNodeToString(this.engine.createClass(this));
-        this.fileSystem.generateFile(this.className, this.parentPath, tsNodeStr);
+        const tsFileStr: string = `${importStr}\n${tsNodeStr}`;
+        this.fileSystem.generateFile(this.className, this.parentPath, tsFileStr);
     }
 
     public typeCheck(): void {

--- a/src/ast/InterfaceDecl.ts
+++ b/src/ast/InterfaceDecl.ts
@@ -46,7 +46,7 @@ export class InterfaceDecl extends Content {
         }
 
         this.typeTable.addInterface(this.interfaceName);
-        this.pathTable.addTypePath(this.interfaceName, this.getAbsolutePath());
+        this.pathTable.addTypePath(this.interfaceName, this.getImportPath());
 
         return this;
     }
@@ -70,6 +70,10 @@ export class InterfaceDecl extends Content {
             this.fieldDecl.typeCheck();
         }
         this.functions.forEach((funcDecl: FuncDecl) => funcDecl.typeCheck());
+    }
+
+    public getImportPath(): string {
+        return `${this.parentPath}/${this.interfaceName}`;
     }
 
     public getAbsolutePath(): string {

--- a/src/ast/InterfaceDecl.ts
+++ b/src/ast/InterfaceDecl.ts
@@ -4,6 +4,7 @@ import {FieldDecl} from "./FieldDecl";
 import CommentDecl from "./CommentDecl";
 import FuncDecl from "./FuncDecl";
 import {Tokenizer} from "../util/Tokenizer";
+import {ImportStringBuilder} from "../util/ImportStringBuilder";
 
 /**
  * Represents an Interface a TypeScript project may have.
@@ -52,8 +53,10 @@ export class InterfaceDecl extends Content {
 
     public evaluate(): any {
         const tsNode = this.engine.createInterface(this);
+        const importStr: string = ImportStringBuilder.getImportsString(this);
         const tsNodeAsString: string = this.printer.tsNodeToString(tsNode);
-        this.fileSystem.generateFile(this.interfaceName, this.parentPath, tsNodeAsString);
+        const tsFileStr: string = `${importStr}\n${tsNodeAsString}`;
+        this.fileSystem.generateFile(this.interfaceName, this.parentPath, tsFileStr);
     }
 
     public typeCheck(): void {

--- a/src/codegen/TypeScriptEngine.ts
+++ b/src/codegen/TypeScriptEngine.ts
@@ -58,7 +58,7 @@ export default class TypeScriptEngine {
 
         return ts.createClassDeclaration(
             undefined,
-            undefined,
+            [ts.createModifier(SyntaxKind.ExportKeyword)],
             classDecl.className,
             undefined,
             undefined,

--- a/src/codegen/TypeScriptEngine.ts
+++ b/src/codegen/TypeScriptEngine.ts
@@ -73,7 +73,7 @@ export default class TypeScriptEngine {
         const interfaceMembers = tsMethodSignatures.concat(tsPropertySignatures);
         const interfaceDeclaration: InterfaceDeclaration = ts.createInterfaceDeclaration(
             /* decorators */ undefined,
-            /* modifiers */ undefined,
+            [ts.createModifier(SyntaxKind.ExportKeyword)],
             interfaceDecl.interfaceName,
             /* typeParams */ undefined,
             /* heritageClauses */ undefined,

--- a/src/util/ImportStringBuilder.ts
+++ b/src/util/ImportStringBuilder.ts
@@ -86,7 +86,6 @@ export class ImportStringBuilder {
                 importStrBody += importStr;
             }
         });
-
         return importStrBody;
     }
 

--- a/src/util/ImportStringBuilder.ts
+++ b/src/util/ImportStringBuilder.ts
@@ -166,9 +166,11 @@ export class ImportStringBuilder {
     private static extractNonPrimitiveTypesFromInterface(interfaceDec: InterfaceDecl): Set<string> {
         let interfaceNonPrimitives = new Set<string>();
 
-        this.extractNonPrimitiveTypesFromVarList(interfaceDec.fieldDecl.fields).forEach((nonPrimitive: string) => {
-            interfaceNonPrimitives.add(nonPrimitive);
-        });
+        if (interfaceDec.fieldDecl !== undefined) {
+            this.extractNonPrimitiveTypesFromVarList(interfaceDec.fieldDecl.fields).forEach((nonPrimitive: string) => {
+                interfaceNonPrimitives.add(nonPrimitive);
+            });
+        }
 
         this.extractNonPrimitivesFromFunctionsAndInheritance(interfaceDec).forEach((nonPrimitive: string) => {
             interfaceNonPrimitives.add(nonPrimitive);

--- a/test/TypeScriptEngine.spec.ts
+++ b/test/TypeScriptEngine.spec.ts
@@ -190,7 +190,7 @@ describe("TypeScriptEngine tests", () => {
         const result: InterfaceDeclaration = engine.createInterface(baseInterfaceDecl);
         expect(result).to.deep.equal(ts.createInterfaceDeclaration(
             /* decorators */ undefined,
-            /* modifiers */ undefined,
+            /* modifiers */ [ts.createModifier(SyntaxKind.ExportKeyword)],
             baseInterfaceDecl.interfaceName,
             /* typeParams */ undefined,
             /* heritageClauses */ undefined,
@@ -210,7 +210,7 @@ describe("TypeScriptEngine tests", () => {
         const result: ClassDeclaration = engine.createClass(baseClassDecl);
         expect(result).to.deep.equal(ts.createClassDeclaration(
             /* decorators */ undefined,
-            /* modifiers */ undefined,
+            /* modifiers */ [ts.createModifier(SyntaxKind.ExportKeyword)],
             baseClassDecl.className,
             /* typeParams */ undefined,
             /* heritageClauses */ undefined,
@@ -229,7 +229,7 @@ describe("TypeScriptEngine tests", () => {
         const result: ClassDeclaration = engine.createClass(baseClassDecl);
         expect(result).to.deep.equal(ts.createClassDeclaration(
             /* decorators */ undefined,
-            /* modifiers */ undefined,
+            /* modifiers */ [ts.createModifier(SyntaxKind.ExportKeyword)],
             baseClassDecl.className,
             /* typeParams */ undefined,
             /* heritageClauses */ undefined,
@@ -258,7 +258,7 @@ describe("TypeScriptEngine tests", () => {
         const result: InterfaceDeclaration = engine.createInterface(baseInterfaceDecl);
         expect(result).to.deep.equal(ts.createInterfaceDeclaration(
             /* decorators */ undefined,
-            /* modifiers */ undefined,
+            /* modifiers */ [ts.createModifier(SyntaxKind.ExportKeyword)],
             name,
             /* typeParams */ undefined,
             /* heritageClauses */ undefined,
@@ -309,7 +309,7 @@ describe("TypeScriptEngine tests", () => {
         const result: InterfaceDeclaration = engine.createInterface(baseInterfaceDecl);
         expect(result).to.deep.equal(ts.createInterfaceDeclaration(
             /* decorators */ undefined,
-            /* modifiers */ undefined,
+            /* modifiers */ [ts.createModifier(SyntaxKind.ExportKeyword)],
             name,
             /* typeParams */ undefined,
             /* heritageClauses */ undefined,
@@ -372,7 +372,7 @@ describe("TypeScriptEngine tests", () => {
         const result: ClassDeclaration = engine.createClass(baseClassDecl);
         expect(result).to.deep.equal(ts.createClassDeclaration(
             /* decorators */ undefined,
-            /* modifiers */ undefined,
+            /* modifiers */ [ts.createModifier(SyntaxKind.ExportKeyword)],
             name,
             /* typeParams */ undefined,
             /* heritageClauses */ undefined,
@@ -436,7 +436,7 @@ describe("TypeScriptEngine tests", () => {
         const result: ClassDeclaration = engine.createClass(baseClassDecl);
         expect(result).to.deep.equal(ts.createClassDeclaration(
             /* decorators */ undefined,
-            /* modifiers */ undefined,
+            /* modifiers */ [ts.createModifier(SyntaxKind.ExportKeyword)],
             name,
             /* typeParams */ undefined,
             /* heritageClauses */ undefined,


### PR DESCRIPTION
## Done:
- Import strings are now generated when Class and Interfaces are evaluated.
- PathTable now carries "import paths" not absolute paths. Paths in import strings don't have a ".ts" so these shouldn't either.
- Classes and Interfaces generated now have a "export" modifier to support imports.