### PR TITLE
Adding support for the visitor pattern (Phase 1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ test/*.map
 .idea/*
 package-lock.json
 codegen/
+*.js

--- a/.gitignore
+++ b/.gitignore
@@ -18,5 +18,5 @@ test/*.map
 
 .idea/*
 package-lock.json
-codegen/
 *.js
+codegen/

--- a/src/ast/AstNode.ts
+++ b/src/ast/AstNode.ts
@@ -19,7 +19,5 @@ export abstract class AstNode {
 
     public abstract evaluate(): any;
 
-    public abstract typeCheck(): void;
-
     public abstract accept(v: Visitor): void;
 }

--- a/src/ast/AstNode.ts
+++ b/src/ast/AstNode.ts
@@ -5,6 +5,7 @@ import TypeScriptEngine from "../codegen/TypeScriptEngine";
 import PrintUtil from "../util/PrintUtil";
 import ts = require("typescript");
 import {PathTable} from "../util/PathTable";
+import Visitor from "../codegen/Visitor";
 
 export abstract class AstNode {
 
@@ -20,11 +21,5 @@ export abstract class AstNode {
 
     public abstract typeCheck(): void;
 
-    /**
-     * This should be run after typeCheck() to modify the AST nodes such that they correctly
-     * fulfill extends/implements contracts, i.e.
-     *  - classes which implement an interface should have the correct method signatures
-     *  - interfaces which extend other interfaces should have the correct method signatures
-     */
-    public abstract fulfillContract(): void;
+    public abstract accept(v: Visitor): void;
 }

--- a/src/ast/AsyncDecl.ts
+++ b/src/ast/AsyncDecl.ts
@@ -20,10 +20,6 @@ export default class AsyncDecl extends AstNode {
         // Not needed.
     }
 
-    public typeCheck(): void {
-        // Not needed.
-    }
-
     public accept(v: Visitor): void {
         v.visitAsyncDecl(this);
     }

--- a/src/ast/AsyncDecl.ts
+++ b/src/ast/AsyncDecl.ts
@@ -3,6 +3,7 @@
  */
 import {AstNode} from "./AstNode";
 import {Tokenizer} from "../util/Tokenizer";
+import Visitor from "../codegen/Visitor";
 
 export default class AsyncDecl extends AstNode {
 
@@ -23,8 +24,8 @@ export default class AsyncDecl extends AstNode {
         // Not needed.
     }
 
-    public fulfillContract(): void {
-        // Not needed.
+    public accept(v: Visitor): void {
+        v.visitAsyncDecl(this);
     }
 
 }

--- a/src/ast/ClassDecl.ts
+++ b/src/ast/ClassDecl.ts
@@ -99,13 +99,6 @@ export class ClassDecl extends Content {
         this.fileSystem.generateFile(this.className, this.parentPath, tsFileStr);
     }
 
-    public typeCheck(): void {
-        if (this.extendsNodes !== undefined) {
-            this.extendsNodes.typeCheck();
-        }
-        this.fields.forEach((fieldDecl: FieldDecl) => fieldDecl.typeCheck());
-        this.functions.forEach((funcDecl: FuncDecl) => funcDecl.typeCheck());
-    }
     public getImportPath(): string {
         return `${this.parentPath}/${this.className}`;
     }

--- a/src/ast/ClassDecl.ts
+++ b/src/ast/ClassDecl.ts
@@ -11,6 +11,7 @@ import StaticDecl from "./StaticDecl";
 import AsyncDecl from "./AsyncDecl";
 import {VarList} from "./VarList";
 import {ParseError, Tokenizer} from "../util/Tokenizer";
+import Visitor from "../codegen/Visitor";
 /**
  * Represents a Class a TypeScript project may have.
  *
@@ -105,26 +106,6 @@ export class ClassDecl extends Content {
         this.fields.forEach((fieldDecl: FieldDecl) => fieldDecl.typeCheck());
         this.functions.forEach((funcDecl: FuncDecl) => funcDecl.typeCheck());
     }
-
-    public fulfillContract(): void {
-        const nodeTable: NodeTable = NodeTable.getInstance();
-        if (this.implementsNodes !== undefined) {
-            const interfacesToImplement: string[] = this.implementsNodes.parentNames;
-            interfacesToImplement.forEach((parentName) => {
-                const interfaceDecl: InterfaceDecl = nodeTable.getNode(parentName) as InterfaceDecl;
-                this.implementInterface(interfaceDecl);
-            });
-        }
-    }
-
-    private implementInterface(interfaceDecl: InterfaceDecl): void {
-        this.functions = this.functions.concat(interfaceDecl.functions);
-        if (interfaceDecl.fieldDecl !== undefined) {
-            this.fields.push(interfaceDecl.fieldDecl);
-        }
-
-    }
-
     public getImportPath(): string {
         return `${this.parentPath}/${this.className}`;
     }
@@ -157,5 +138,9 @@ export class ClassDecl extends Content {
         funcSetter.params.addPair(name, type);
         funcSetter.comments = new CommentDecl();
         return funcSetter;
+    }
+
+    public accept(v: Visitor): void {
+        v.visitClassDecl(this);
     }
 }

--- a/src/ast/CommentDecl.ts
+++ b/src/ast/CommentDecl.ts
@@ -32,10 +32,6 @@ export default class CommentDecl extends AstNode {
         // Not needed.
     }
 
-    public typeCheck(): void {
-        // Not needed.
-    }
-
     public accept(v: Visitor): void {
         v.visitCommentDecl(this);
     }

--- a/src/ast/CommentDecl.ts
+++ b/src/ast/CommentDecl.ts
@@ -1,5 +1,6 @@
 import {AstNode} from "./AstNode";
 import {Tokenizer} from "../util/Tokenizer";
+import Visitor from "../codegen/Visitor";
 
 /**
  * Represents the comments that a class, interface, or method may have
@@ -35,8 +36,8 @@ export default class CommentDecl extends AstNode {
         // Not needed.
     }
 
-    public fulfillContract(): void {
-        // Not needed.
+    public accept(v: Visitor): void {
+        v.visitCommentDecl(this);
     }
 
 }

--- a/src/ast/ConstructorDecl.ts
+++ b/src/ast/ConstructorDecl.ts
@@ -30,10 +30,6 @@ export default class ConstructorDecl extends AstNode {
         // TODO: implement this.
     }
 
-    public typeCheck(): void {
-        this.params.typeCheck();
-    }
-
     public accept(v: Visitor): void {
         v.visitConstructorDecl(this);
     }

--- a/src/ast/ConstructorDecl.ts
+++ b/src/ast/ConstructorDecl.ts
@@ -1,6 +1,7 @@
 import {AstNode} from "./AstNode";
 import {VarList} from "./VarList";
 import {Tokenizer} from "../util/Tokenizer";
+import Visitor from "../codegen/Visitor";
 
 /**
  * This represents a constructor as a node in our AST
@@ -33,7 +34,7 @@ export default class ConstructorDecl extends AstNode {
         this.params.typeCheck();
     }
 
-    public fulfillContract(): void {
-        // Not needed.
+    public accept(v: Visitor): void {
+        v.visitConstructorDecl(this);
     }
 }

--- a/src/ast/DirDecl.ts
+++ b/src/ast/DirDecl.ts
@@ -66,10 +66,6 @@ export class DirDecl extends Content {
         return this.parentPath + "/" + this.directoryName;
     }
 
-    public typeCheck(): void {
-        this.contents.forEach((content: AstNode) => content.typeCheck());
-    }
-
     public accept(v: Visitor): void {
         v.visitDirDecl(this);
     }

--- a/src/ast/DirDecl.ts
+++ b/src/ast/DirDecl.ts
@@ -8,6 +8,7 @@ import {Tokenizer} from "../util/Tokenizer";
 import {ClassDecl} from "./ClassDecl";
 import {InterfaceDecl} from "./InterfaceDecl";
 import {AstNode} from "./AstNode";
+import Visitor from "../codegen/Visitor";
 
 export class DirDecl extends Content {
     directoryName: string;
@@ -69,7 +70,7 @@ export class DirDecl extends Content {
         this.contents.forEach((content: AstNode) => content.typeCheck());
     }
 
-    public fulfillContract(): void {
-        this.contents.forEach((content: AstNode) => content.fulfillContract());
+    public accept(v: Visitor): void {
+        v.visitDirDecl(this);
     }
 }

--- a/src/ast/ExtendsDecl.ts
+++ b/src/ast/ExtendsDecl.ts
@@ -22,13 +22,6 @@ export class ExtendsDecl extends AstNode {
         // Not needed.
     }
 
-    public typeCheck(): void {
-        const wasDeclared: boolean = this.typeTable.isValidType(this.parentName);
-        if (!wasDeclared) {
-            throw new TypeCheckError(`Type: ${this.parentName} was not defined`);
-        }
-    }
-
     public accept(v: Visitor): void {
         v.visitExtendsDecl(this);
     }

--- a/src/ast/ExtendsDecl.ts
+++ b/src/ast/ExtendsDecl.ts
@@ -6,6 +6,7 @@
 import {AstNode} from "./AstNode";
 import {Tokenizer} from "../util/Tokenizer";
 import {TypeCheckError} from "./symbols/TypeTable";
+import Visitor from "../codegen/Visitor";
 
 export class ExtendsDecl extends AstNode {
     parentName: string;
@@ -28,7 +29,7 @@ export class ExtendsDecl extends AstNode {
         }
     }
 
-    public fulfillContract(): void {
-        // Not needed.
+    public accept(v: Visitor): void {
+        v.visitExtendsDecl(this);
     }
 }

--- a/src/ast/FieldDecl.ts
+++ b/src/ast/FieldDecl.ts
@@ -55,13 +55,6 @@ export class FieldDecl extends AstNode {
         // TODO: implement this.
     }
 
-    public typeCheck(): void {
-        if(this.isInterfaceField && this.modifier !== "public") {
-            throw new ValidationError("Interfaces cannot have non-public fields");
-        }
-        this.fields.typeCheck();
-    }
-
     public accept(v: Visitor): void {
         v.visitFieldDecl(this);
     }

--- a/src/ast/FieldDecl.ts
+++ b/src/ast/FieldDecl.ts
@@ -2,6 +2,7 @@ import {VarList} from "./VarList";
 import {ParseError, Tokenizer} from "../util/Tokenizer";
 import {ValidationError} from "./errors/ASTErrors";
 import {AstNode} from "./AstNode";
+import Visitor from "../codegen/Visitor";
 
 /**
  * Represents a field declaration in the TypeScript DSL.
@@ -61,7 +62,7 @@ export class FieldDecl extends AstNode {
         this.fields.typeCheck();
     }
 
-    public fulfillContract(): void {
-        // Not needed.
+    public accept(v: Visitor): void {
+        v.visitFieldDecl(this);
     }
 }

--- a/src/ast/FuncDecl.ts
+++ b/src/ast/FuncDecl.ts
@@ -75,11 +75,6 @@ export default class FuncDecl extends AstNode {
         // TODO: implement this.
     }
 
-    public typeCheck(): void {
-        this.params.typeCheck();
-        this.returnDecl.typeCheck();
-    }
-
     public accept(v: Visitor): void {
         v.visitFuncDecl(this);
     }

--- a/src/ast/FuncDecl.ts
+++ b/src/ast/FuncDecl.ts
@@ -5,6 +5,7 @@ import {Tokenizer} from "../util/Tokenizer";
 import StaticDecl from "./StaticDecl";
 import AsyncDecl from "./AsyncDecl";
 import ReturnDecl from "./ReturnDecl";
+import Visitor from "../codegen/Visitor";
 
 /**
  * Represents a function declaration in our language
@@ -79,7 +80,7 @@ export default class FuncDecl extends AstNode {
         this.returnDecl.typeCheck();
     }
 
-    public fulfillContract(): void {
-        // Not needed.
+    public accept(v: Visitor): void {
+        v.visitFuncDecl(this);
     }
 }

--- a/src/ast/ImplementsDecl.ts
+++ b/src/ast/ImplementsDecl.ts
@@ -5,6 +5,7 @@
  */
 import {AstNode} from "./AstNode";
 import {Tokenizer} from "../util/Tokenizer";
+import Visitor from "../codegen/Visitor";
 
 export class ImplementsDecl extends AstNode {
     parentNames: string[];
@@ -33,7 +34,7 @@ export class ImplementsDecl extends AstNode {
         }
     }
 
-    public fulfillContract(): void {
-        // Not needed.
+    public accept(v: Visitor): void {
+        v.visitImplementsDecl(this);
     }
 }

--- a/src/ast/ImplementsDecl.ts
+++ b/src/ast/ImplementsDecl.ts
@@ -27,13 +27,6 @@ export class ImplementsDecl extends AstNode {
         // Not needed.
     }
 
-    public typeCheck(): void {
-        const allValidTypes: boolean = this.typeTable.areValidTypes(this.parentNames);
-        if (!allValidTypes) {
-            throw new TypeError(`At least one type from: ${this.parentNames} was not declared`);
-        }
-    }
-
     public accept(v: Visitor): void {
         v.visitImplementsDecl(this);
     }

--- a/src/ast/InterfaceDecl.ts
+++ b/src/ast/InterfaceDecl.ts
@@ -87,19 +87,6 @@ export class InterfaceDecl extends Content {
         this.fileSystem.generateFile(this.interfaceName, this.parentPath, tsFileStr);
     }
 
-    public typeCheck(): void {
-        if (this.extendsNodes !== undefined) {
-            this.extendsNodes.typeCheck();
-        }
-        if(this.extendsNodes) {
-            this.extendsNodes.typeCheck();
-        }
-        if(this.fieldDecl) {
-            this.fieldDecl.typeCheck();
-        }
-        this.functions.forEach((funcDecl: FuncDecl) => funcDecl.typeCheck());
-    }
-      
     public getImportPath(): string {
         return `${this.parentPath}/${this.interfaceName}`;
     }

--- a/src/ast/InterfaceDecl.ts
+++ b/src/ast/InterfaceDecl.ts
@@ -9,6 +9,7 @@ import StaticDecl from "./StaticDecl";
 import AsyncDecl from "./AsyncDecl";
 import {VarList} from "./VarList";
 import {ParseError, Tokenizer} from "../util/Tokenizer";
+import Visitor from "../codegen/Visitor";
 
 /**
  * Represents an Interface a TypeScript project may have.
@@ -98,30 +99,6 @@ export class InterfaceDecl extends Content {
         }
         this.functions.forEach((funcDecl: FuncDecl) => funcDecl.typeCheck());
     }
-
-    public fulfillContract(): void {
-        if (this.extendsNodes !== undefined) {
-            const parentNode: InterfaceDecl =
-                NodeTable.getInstance().getNode(this.extendsNodes.parentName) as InterfaceDecl;
-            this.addParentFunctions(parentNode);
-            this.addParentFields(parentNode);
-
-        }
-    }
-
-    private addParentFunctions(parentNode: InterfaceDecl): void {
-        this.functions = this.functions.concat(parentNode.functions)
-    }
-
-    private addParentFields(parentNode: InterfaceDecl): void {
-        if (parentNode.fieldDecl !== undefined) {
-            if (this.fieldDecl === undefined) {
-                this.fieldDecl = new FieldDecl();
-                this.fieldDecl.fields = new VarList();
-            }
-            this.fieldDecl.fields.appendVarList(parentNode.fieldDecl.fields);
-        }
-    }
       
     public getImportPath(): string {
         return `${this.parentPath}/${this.interfaceName}`;
@@ -158,5 +135,9 @@ export class InterfaceDecl extends Content {
         funcSetter.params.addPair(name, type);
         funcSetter.comments = new CommentDecl();
         return funcSetter;
+    }
+
+    public accept(v: Visitor): void {
+        v.visitInterfaceDecl(this);
     }
 }

--- a/src/ast/ModuleDecl.ts
+++ b/src/ast/ModuleDecl.ts
@@ -43,10 +43,6 @@ export class ModuleDecl extends AstNode {
         return packageJson.addModules(this.modules);
     }
 
-    public typeCheck(): void {
-        // Not needed.
-    }
-
     public setProjectName(name: string) {
         this.projectName = name;
     }

--- a/src/ast/ModuleDecl.ts
+++ b/src/ast/ModuleDecl.ts
@@ -6,6 +6,7 @@
 import { AstNode } from "./AstNode";
 import { Tokenizer } from "../util/Tokenizer";
 import PackageJson from "../util/PackageJson";
+import Visitor from "../codegen/Visitor";
 
 export class ModuleDecl extends AstNode {
 
@@ -46,15 +47,15 @@ export class ModuleDecl extends AstNode {
         // Not needed.
     }
 
-    public fulfillContract(): void {
-        // Not needed.
-    }
-
     public setProjectName(name: string) {
         this.projectName = name;
     }
 
     public setPath(path: string) {
         this.path = path;
+    }
+
+    public accept(v: Visitor): void {
+        v.visitModuleDecl(this);
     }
 }

--- a/src/ast/ReturnDecl.ts
+++ b/src/ast/ReturnDecl.ts
@@ -4,6 +4,7 @@
 import {AstNode} from "./AstNode";
 import {Tokenizer} from "../util/Tokenizer";
 import {TypeCheckError} from "./symbols/TypeTable";
+import Visitor from "../codegen/Visitor";
 
 export default class ReturnDecl extends AstNode {
 
@@ -29,7 +30,7 @@ export default class ReturnDecl extends AstNode {
         }
     }
 
-    public fulfillContract(): void {
-        // Not needed.
+    public accept(v: Visitor): void {
+        v.visitReturnDecl(this);
     }
 }

--- a/src/ast/ReturnDecl.ts
+++ b/src/ast/ReturnDecl.ts
@@ -23,13 +23,6 @@ export default class ReturnDecl extends AstNode {
 
     }
 
-    public typeCheck(): void {
-        const wasDeclared: boolean = this.typeTable.isValidType(this.returnType.replace(/[\[\]]/g, ""));
-        if (!wasDeclared) {
-            throw new TypeCheckError(`Type: ${this.returnType} was not defined`);
-        }
-    }
-
     public accept(v: Visitor): void {
         v.visitReturnDecl(this);
     }

--- a/src/ast/StaticDecl.ts
+++ b/src/ast/StaticDecl.ts
@@ -3,6 +3,7 @@
  */
 import {AstNode} from "./AstNode";
 import {Tokenizer} from "../util/Tokenizer";
+import Visitor from "../codegen/Visitor";
 
 export default class StaticDecl extends AstNode {
 
@@ -23,7 +24,7 @@ export default class StaticDecl extends AstNode {
         // Not needed.
     }
 
-    public fulfillContract(): void {
-        // Not needed.
+    public accept(v: Visitor): void {
+        v.visitStaticDecl(this);
     }
 }

--- a/src/ast/StaticDecl.ts
+++ b/src/ast/StaticDecl.ts
@@ -20,10 +20,6 @@ export default class StaticDecl extends AstNode {
         // Not needed.
     }
 
-    public typeCheck(): void {
-        // Not needed.
-    }
-
     public accept(v: Visitor): void {
         v.visitStaticDecl(this);
     }

--- a/src/ast/VarList.ts
+++ b/src/ast/VarList.ts
@@ -37,18 +37,6 @@ export class VarList extends AstNode {
         // Not needed.
     }
 
-    public typeCheck(): void {
-        const fieldTypes: string[] = Array.from(this.nameTypeMap.values())
-            .map((fieldType) => {
-                // filter out [] from type before checking against typeTable
-                return fieldType.replace(/[\[\]]/g, "");
-        });
-        const allValidTypes: boolean = this.typeTable.areValidTypes(fieldTypes);
-        if (!allValidTypes) {
-            throw new TypeCheckError(`At least one type from: ${fieldTypes} was not declared`);
-        }
-    }
-
     public appendVarList(otherVars: VarList): void {
         const fieldsAsList: [string, string][] = Array.from(otherVars.nameTypeMap.entries());
         fieldsAsList.forEach((nameTypePair) => {

--- a/src/ast/VarList.ts
+++ b/src/ast/VarList.ts
@@ -1,6 +1,7 @@
 import { AstNode } from "./AstNode";
 import {Tokenizer} from "../util/Tokenizer";
 import {TypeCheckError} from "./symbols/TypeTable";
+import Visitor from "../codegen/Visitor";
 
 /**
  * Represents a list of fields and their corresponding type. Used in declaring fields.
@@ -55,7 +56,7 @@ export class VarList extends AstNode {
         });
     }
 
-    public fulfillContract(): void {
-        // Not needed.
+    public accept(v: Visitor): void {
+        v.visitVarList(this);
     }
 }

--- a/src/codegen/InheritanceVisitor.ts
+++ b/src/codegen/InheritanceVisitor.ts
@@ -1,0 +1,57 @@
+import Visitor from "./Visitor";
+import NodeTable from "../ast/symbols/NodeTable";
+import {ClassDecl} from "../ast/ClassDecl";
+import {InterfaceDecl} from "../ast/InterfaceDecl";
+import {DirDecl} from "../ast/DirDecl";
+import {AstNode} from "../ast/AstNode";
+import {FieldDecl} from "../ast/FieldDecl";
+import {VarList} from "../ast/VarList";
+
+export default class InheritanceVisitor extends Visitor {
+
+    private nodeTable: NodeTable = NodeTable.getInstance();
+
+    public visitClassDecl(node: ClassDecl): void {
+        if (node.implementsNodes !== undefined) {
+            const interfacesToImplement: string[] = node.implementsNodes.parentNames;
+            interfacesToImplement.forEach((parentName) => {
+                const interfaceDecl: InterfaceDecl = this.nodeTable.getNode(parentName) as InterfaceDecl;
+                this.implementInterface(node, interfaceDecl);
+            });
+        }
+    }
+
+    public visitDirDecl(node: DirDecl): void {
+        node.contents.forEach((content: AstNode) => content.accept(this));
+    }
+
+    public visitInterfaceDecl(node: InterfaceDecl): void {
+        if (node.extendsNodes !== undefined) {
+            const parentName: string = node.extendsNodes.parentName;
+            const parentNode: InterfaceDecl = this.nodeTable.getNode(parentName) as InterfaceDecl;
+            this.addParentFunctions(node, parentNode);
+            this.addParentFields(node, parentNode);
+        }
+    }
+
+    private implementInterface(implementor: ClassDecl, toImplement: InterfaceDecl): void {
+        implementor.functions = implementor.functions.concat(toImplement.functions);
+        if (toImplement.fieldDecl !== undefined) {
+            implementor.fields.push(toImplement.fieldDecl);
+        }
+    }
+
+    private addParentFunctions(childNode: InterfaceDecl, parentNode: InterfaceDecl): void {
+        childNode.functions = childNode.functions.concat(parentNode.functions);
+    }
+
+    private addParentFields(childNode: InterfaceDecl, parentNode: InterfaceDecl): void {
+        if (parentNode.fieldDecl !== undefined) {
+            if (childNode.fieldDecl === undefined) {
+                childNode.fieldDecl = new FieldDecl();
+                childNode.fieldDecl.fields = new VarList();
+            }
+            childNode.fieldDecl.fields.appendVarList(parentNode.fieldDecl.fields);
+        }
+    }
+}

--- a/src/codegen/TypeCheckVisitor.ts
+++ b/src/codegen/TypeCheckVisitor.ts
@@ -1,0 +1,91 @@
+import Visitor from "./Visitor";
+import {FieldDecl} from "../ast/FieldDecl";
+import FuncDecl from "../ast/FuncDecl";
+import {ClassDecl} from "../ast/ClassDecl";
+import ConstructorDecl from "../ast/ConstructorDecl";
+import {AstNode} from "../ast/AstNode";
+import {DirDecl} from "../ast/DirDecl";
+import {TypeCheckError, TypeTable} from "../ast/symbols/TypeTable";
+import {ExtendsDecl} from "../ast/ExtendsDecl";
+import {ValidationError} from "../ast/errors/ASTErrors";
+import {ImplementsDecl} from "../ast/ImplementsDecl";
+import {InterfaceDecl} from "../ast/InterfaceDecl";
+import ReturnDecl from "../ast/ReturnDecl";
+import {VarList} from "../ast/VarList";
+
+export default class TypeCheckVisitor extends Visitor {
+
+    private typeTable: TypeTable = TypeTable.getInstance();
+
+    public visitClassDecl(node: ClassDecl): void {
+        if (node.extendsNodes !== undefined) {
+            node.extendsNodes.accept(this);
+        }
+        node.fields.forEach((fieldDecl: FieldDecl) => fieldDecl.accept(this));
+        node.functions.forEach((funcDecl: FuncDecl) => funcDecl.accept(this));
+    }
+
+    public visitConstructorDecl(node: ConstructorDecl): void {
+        node.params.accept(this);
+    }
+
+    public visitDirDecl(node: DirDecl): void {
+        node.contents.forEach((content: AstNode) => content.accept(this));
+    }
+
+    public visitExtendsDecl(node: ExtendsDecl): void {
+        const wasDeclared: boolean = this.typeTable.isValidType(node.parentName);
+        if (!wasDeclared) {
+            throw new TypeCheckError(`Type: ${node.parentName} was not defined`);
+        }
+    }
+
+    public visitFieldDecl(node: FieldDecl): void {
+        if (node.isInterfaceField && node.modifier !== "public") {
+            throw new ValidationError("Interfaces cannot have non-public fields");
+        }
+        node.fields.accept(this);
+    }
+
+    public visitFuncDecl(node: FuncDecl): void {
+        node.params.accept(this);
+        node.returnDecl.accept(this);
+    }
+
+    public visitImplementsDecl(node: ImplementsDecl): void {
+        const allValidTypes: boolean = this.typeTable.areValidTypes(node.parentNames);
+        if (!allValidTypes) {
+            throw new TypeError(`At least one type from: ${node.parentNames} was not declared`);
+        }
+    }
+
+    public visitInterfaceDecl(node: InterfaceDecl): void {
+        if (node.extendsNodes !== undefined) {
+            node.extendsNodes.accept(this);
+        }
+        if(node.fieldDecl) {
+            node.fieldDecl.accept(this);
+        }
+        node.functions.forEach((funcDecl: FuncDecl) => funcDecl.accept(this));
+    }
+
+    public visitReturnDecl(node: ReturnDecl): void {
+        const wasDeclared: boolean =
+            this.typeTable.isValidType(node.returnType.replace(/[\[\]]/g, ""));
+        if (!wasDeclared) {
+            throw new TypeCheckError(`Type: ${node.returnType} was not defined`);
+        }
+    }
+
+    public visitVarList(node: VarList): void {
+        const fieldTypes: string[] = Array.from(node.nameTypeMap.values())
+            .map((fieldType) => {
+                // filter out [] from type before checking against typeTable
+                return fieldType.replace(/[\[\]]/g, "");
+            });
+        const allValidTypes: boolean = this.typeTable.areValidTypes(fieldTypes);
+        if (!allValidTypes) {
+            throw new TypeCheckError(`At least one type from: ${fieldTypes} was not declared`);
+        }
+    }
+}

--- a/src/codegen/Visitor.ts
+++ b/src/codegen/Visitor.ts
@@ -1,0 +1,84 @@
+import AsyncDecl from "../ast/AsyncDecl";
+import {ClassDecl} from "../ast/ClassDecl";
+import CommentDecl from "../ast/CommentDecl";
+import ConstructorDecl from "../ast/ConstructorDecl";
+import {Content} from "../ast/Content";
+import {DirDecl} from "../ast/DirDecl";
+import {ExtendsDecl} from "../ast/ExtendsDecl";
+import {FieldDecl} from "../ast/FieldDecl";
+import FuncDecl from "../ast/FuncDecl";
+import {ImplementsDecl} from "../ast/ImplementsDecl";
+import {InterfaceDecl} from "../ast/InterfaceDecl";
+import {ModuleDecl} from "../ast/ModuleDecl";
+import {ProgramDecl} from "../ast/ProgramDecl";
+import ReturnDecl from "../ast/ReturnDecl";
+import StaticDecl from "../ast/StaticDecl";
+import {VarList} from "../ast/VarList";
+
+export default abstract class Visitor {
+
+    public visitAsyncDecl(node: AsyncDecl): void {
+
+    }
+
+    public visitClassDecl(node: ClassDecl): void {
+
+    }
+
+    public visitCommentDecl(node: CommentDecl): void {
+
+    }
+
+    public visitConstructorDecl(node: ConstructorDecl): void {
+
+    }
+
+    public visitContent(node: Content): void {
+
+    }
+
+    public visitDirDecl(node: DirDecl): void {
+
+    }
+
+    public visitExtendsDecl(node: ExtendsDecl): void {
+
+    }
+
+    public visitFieldDecl(node: FieldDecl): void {
+
+    }
+
+    public visitFuncDecl(node: FuncDecl): void {
+
+    }
+
+    public visitImplementsDecl(node: ImplementsDecl): void {
+
+    }
+
+    public visitInterfaceDecl(node: InterfaceDecl): void {
+
+    }
+
+    public visitModuleDecl(node: ModuleDecl): void {
+
+    }
+
+    public visitProgramDecl(node: ProgramDecl): void {
+
+    }
+
+    public visitReturnDecl(node: ReturnDecl): void {
+
+    }
+
+    public visitStaticDecl(node: StaticDecl): void {
+
+    }
+
+    public visitVarList(node: VarList): void {
+
+    }
+
+}

--- a/test/ast/ClassDecl.spec.ts
+++ b/test/ast/ClassDecl.spec.ts
@@ -3,6 +3,7 @@ import {ClassDecl} from "../../src/ast/ClassDecl";
 import {ParseError, Tokenizer, TokenizerError} from "../../src/util/Tokenizer";
 import {TypeCheckError, TypeTable} from "../../src/ast/symbols/TypeTable";
 import * as nodeFs from "fs-extra";
+import TypeCheckVisitor from "../../src/codegen/TypeCheckVisitor";
 
 describe("ClassDecl parse test", () => {
 
@@ -88,13 +89,14 @@ describe("ClassDecl parse test", () => {
 
 describe("ClassDecl type check test", () => {
     const DUMMY_ROOT_DIR: string = ".";
+    const typeChecker = new TypeCheckVisitor();
 
     it("should throw a TypeCheckError when it attempts to extend a undeclared class", () => {
         let tokenizer : Tokenizer = new Tokenizer("classDeclSimple.txt", "./test/testFiles");
         let classDec : ClassDecl = new ClassDecl(DUMMY_ROOT_DIR);
         classDec.parse(tokenizer);
         expect(() => {
-            return classDec.typeCheck();
+            return classDec.accept(typeChecker);
         }).to.throw(TypeCheckError);
     });
 
@@ -103,7 +105,7 @@ describe("ClassDecl type check test", () => {
         let classDec : ClassDecl = new ClassDecl(DUMMY_ROOT_DIR);
         classDec.parse(tokenizer);
         TypeTable.getInstance().addClass("TimeClass");
-        classDec.typeCheck();
+        classDec.accept(typeChecker);
     });
 
 });

--- a/test/ast/FieldDecl.spec.ts
+++ b/test/ast/FieldDecl.spec.ts
@@ -2,6 +2,7 @@ import {ParseError, Tokenizer} from "../../src/util/Tokenizer";
 import {FieldDecl} from "../../src/ast/FieldDecl";
 import {expect} from "chai";
 import {TypeCheckError, TypeTable} from "../../src/ast/symbols/TypeTable";
+import TypeCheckVisitor from "../../src/codegen/TypeCheckVisitor";
 
 describe("FieldDecl tokenizer test", () => {
 
@@ -50,7 +51,8 @@ describe("FieldDecl tokenizer test", () => {
         TypeTable.getInstance().resetTypeTable();
         fieldDecl.parse(tokenizer);
         expect(() => {
-            return fieldDecl.typeCheck();
+            const typeChecker: TypeCheckVisitor = new TypeCheckVisitor();
+            return fieldDecl.accept(typeChecker);
         }).to.throw(TypeCheckError);
     });
 });

--- a/test/ast/FuncDecl.spec.ts
+++ b/test/ast/FuncDecl.spec.ts
@@ -2,10 +2,12 @@ import { expect } from "chai";
 import FuncDecl from "../../src/ast/FuncDecl";
 import {Tokenizer} from "../../src/util/Tokenizer";
 import {TypeCheckError, TypeTable} from "../../src/ast/symbols/TypeTable";
+import TypeCheckVisitor from "../../src/codegen/TypeCheckVisitor";
 
 describe("FuncDecl parse tests", () => {
 
     let funcDecl: FuncDecl;
+    const typeChecker: TypeCheckVisitor = new TypeCheckVisitor();
 
     before(() => {
         funcDecl = new FuncDecl();
@@ -115,7 +117,7 @@ describe("FuncDecl parse tests", () => {
         const tokenizer: Tokenizer = new Tokenizer("funcDeclUndefinedType.txt", "./test/testFiles");
         funcDecl.parse(tokenizer);
         expect(() => {
-            return funcDecl.typeCheck();
+            return funcDecl.accept(typeChecker);
         }).to.throw(TypeCheckError);
     });
 
@@ -124,7 +126,7 @@ describe("FuncDecl parse tests", () => {
         const tokenizer: Tokenizer = new Tokenizer("funcDeclParameterized.txt", "./test/testFiles");
         funcDecl.parse(tokenizer);
         expect(() => {
-            return funcDecl.typeCheck();
+            return funcDecl.accept(typeChecker);
         }).to.throw(TypeCheckError);
     });
 

--- a/test/ast/InterfaceDecl.spec.ts
+++ b/test/ast/InterfaceDecl.spec.ts
@@ -4,6 +4,7 @@ import {InterfaceDecl} from "../../src/ast/InterfaceDecl";
 import {TypeTable} from "../../src/ast/symbols/TypeTable";
 import {ValidationError} from "../../src/ast/errors/ASTErrors";
 import InheritanceVisitor from "../../src/codegen/InheritanceVisitor";
+import TypeCheckVisitor from "../../src/codegen/TypeCheckVisitor";
 
 describe("InterfaceDecl parse test", () => {
     it("parses single-line, simple interface definition", () => {
@@ -70,12 +71,15 @@ describe("InterfaceDecl evaluate test", () => {
 });
 
 describe("InterfaceDecl typeCheck test", () => {
+
+    const typeChecker: TypeCheckVisitor = new TypeCheckVisitor();
+
     it("throws a validation error when the modifier for an interface is not public", () => {
         let tokenizer: Tokenizer = new Tokenizer("interfaceDeclInvalidFieldMod.txt", "./test/testFiles");
         let intDec: InterfaceDecl = new InterfaceDecl(".");
         intDec.parse(tokenizer);
         expect(() => {
-            intDec.typeCheck()
+            intDec.accept(typeChecker);
         }).to.throw(ValidationError);
     });
 
@@ -84,7 +88,7 @@ describe("InterfaceDecl typeCheck test", () => {
         let intDec: InterfaceDecl = new InterfaceDecl(".");
         intDec.parse(tokenizer);
         expect(() => {
-            intDec.typeCheck()
+            intDec.accept(typeChecker);
         }).to.not.throw(ValidationError);
 
     });
@@ -94,7 +98,7 @@ describe("InterfaceDecl typeCheck test", () => {
         let intDec: InterfaceDecl = new InterfaceDecl(".");
         intDec.parse(tokenizer);
         expect(() => {
-            intDec.typeCheck()
+            intDec.accept(typeChecker);
         }).to.not.throw(ValidationError);
 
     });

--- a/test/ast/InterfaceDecl.spec.ts
+++ b/test/ast/InterfaceDecl.spec.ts
@@ -3,6 +3,7 @@ import {ParseError, Tokenizer, TokenizerError} from "../../src/util/Tokenizer";
 import {InterfaceDecl} from "../../src/ast/InterfaceDecl";
 import {TypeTable} from "../../src/ast/symbols/TypeTable";
 import {ValidationError} from "../../src/ast/errors/ASTErrors";
+import InheritanceVisitor from "../../src/codegen/InheritanceVisitor";
 
 describe("InterfaceDecl parse test", () => {
     it("parses single-line, simple interface definition", () => {
@@ -53,7 +54,8 @@ describe("InterfaceDecl parse test", () => {
         tokenizer = new Tokenizer("interfaceDeclExtendsSimple.txt", "./test/testFiles");
         let childDec: InterfaceDecl = new InterfaceDecl(".");
         childDec.parse(tokenizer);
-        childDec.fulfillContract();
+        const inheritanceVisitor: InheritanceVisitor = new InheritanceVisitor();
+        childDec.accept(inheritanceVisitor);
         expect(childDec.comments).to.be.undefined;
         expect(childDec.fieldDecl).to.be.undefined;
         expect(childDec.functions.length).to.equal(2);

--- a/test/ast/ProgramDecl.spec.ts
+++ b/test/ast/ProgramDecl.spec.ts
@@ -1,14 +1,16 @@
 import {Tokenizer} from "../../src/util/Tokenizer";
-import {expect} from "chai";
 import {ProgramDecl} from "../../src/ast/ProgramDecl";
+import TypeCheckVisitor from "../../src/codegen/TypeCheckVisitor";
 
 describe("Top-level TypeScript DSL tests", () => {
+
+    const typeChecker: TypeCheckVisitor = new TypeCheckVisitor();
 
     it("Should evaluate the simplest program", () => {
         const tokenizer: Tokenizer = new Tokenizer("simpleProgram.txt", "./test/testFiles");
         let programDecl: ProgramDecl = new ProgramDecl(".");
         programDecl.parse(tokenizer);
-        programDecl.typeCheck();
+        programDecl.accept(typeChecker);
         programDecl.evaluate();
     });
 
@@ -16,7 +18,7 @@ describe("Top-level TypeScript DSL tests", () => {
         const tokenizer: Tokenizer = new Tokenizer("simpleProgramClass.txt", "./test/testFiles");
         let programDecl: ProgramDecl = new ProgramDecl(".");
         programDecl.parse(tokenizer);
-        programDecl.typeCheck();
+        programDecl.accept(typeChecker);
         programDecl.evaluate();
     });
 });

--- a/test/ast/ReturnDecl.spec.ts
+++ b/test/ast/ReturnDecl.spec.ts
@@ -1,14 +1,15 @@
 import {Tokenizer} from "../../src/util/Tokenizer";
 import {expect} from "chai";
 import ReturnDecl from "../../src/ast/ReturnDecl";
+import TypeCheckVisitor from "../../src/codegen/TypeCheckVisitor";
 
 describe("ReturnDecl typecheck", () => {
     it("ReturnDecl typecheck handles collections", () => {
+        const typeChecker: TypeCheckVisitor = new TypeCheckVisitor();
         let tokenizer: Tokenizer = new Tokenizer("returnsWithCollection.txt", "./test/testFiles");
         let retDecl: ReturnDecl = new ReturnDecl();
         retDecl.parse(tokenizer);
-
         expect(retDecl.returnType).to.equal("number[]");
-        retDecl.typeCheck();
+        retDecl.accept(typeChecker);
     });
 });

--- a/test/ast/VarList.spec.ts
+++ b/test/ast/VarList.spec.ts
@@ -1,14 +1,15 @@
 import { expect } from "chai";
 import {Tokenizer} from "../../src/util/Tokenizer";
 import {VarList} from "../../src/ast/VarList";
+import TypeCheckVisitor from "../../src/codegen/TypeCheckVisitor";
 
 describe("VarList typecheck", () => {
     it("VarList typecheck handles collections", () => {
+        const typeChecker: TypeCheckVisitor = new TypeCheckVisitor();
         let tokenizer: Tokenizer = new Tokenizer("varListWithCollections.txt", "./test/testFiles");
         let varList: VarList = new VarList();
         varList.parse(tokenizer);
-
         expect(varList.nameTypeMap.size).to.equal(3);
-        varList.typeCheck();
+        varList.accept(typeChecker);
     });
 });

--- a/ui/TypeScript.ts
+++ b/ui/TypeScript.ts
@@ -1,15 +1,18 @@
 import {Tokenizer} from "../src/util/Tokenizer";
 import {ProgramDecl} from "../src/ast/ProgramDecl";
+import {AstNode} from "../src/ast/AstNode";
+import InheritanceVisitor from "../src/codegen/InheritanceVisitor";
 
 const args: string[] = process.argv.slice(2);
 const fileToParse: string = args[0];
 
 let tokenizer: Tokenizer = new Tokenizer(fileToParse, "../ui");
-let program: ProgramDecl = new ProgramDecl(".");
+let program: AstNode = new ProgramDecl(".");
+let inheritanceVisitor: InheritanceVisitor = new InheritanceVisitor();
 console.log("Parsing your program...");
 program.parse(tokenizer);
 console.log("Typechecking your program...");
 program.typeCheck();
 console.log("Generating your program...");
-program.fulfillContract();
+program.accept(inheritanceVisitor);
 program.evaluate();

--- a/ui/TypeScript.ts
+++ b/ui/TypeScript.ts
@@ -2,17 +2,19 @@ import {Tokenizer} from "../src/util/Tokenizer";
 import {ProgramDecl} from "../src/ast/ProgramDecl";
 import {AstNode} from "../src/ast/AstNode";
 import InheritanceVisitor from "../src/codegen/InheritanceVisitor";
+import TypeCheckVisitor from "../src/codegen/TypeCheckVisitor";
 
 const args: string[] = process.argv.slice(2);
 const fileToParse: string = args[0];
 
 let tokenizer: Tokenizer = new Tokenizer(fileToParse, "../ui");
 let program: AstNode = new ProgramDecl(".");
-let inheritanceVisitor: InheritanceVisitor = new InheritanceVisitor();
+const inheritanceVisitor: InheritanceVisitor = new InheritanceVisitor();
+const typeChecker: TypeCheckVisitor = new TypeCheckVisitor();
 console.log("Parsing your program...");
 program.parse(tokenizer);
 console.log("Typechecking your program...");
-program.typeCheck();
+program.accept(typeChecker);
 console.log("Generating your program...");
 program.accept(inheritanceVisitor);
 program.evaluate();


### PR DESCRIPTION
**What's new?**

* added support for the Visitor pattern to traverse the AST
* type checking now performed via visitor
* inheritance contracts now fulfilled via visitor

**Future work**
* `parse()` via visitor
* `evaluate()` via visitor
